### PR TITLE
주문하기 API 구현

### DIFF
--- a/app/src/test/java/com/food/SuperIntegrationTest.java
+++ b/app/src/test/java/com/food/SuperIntegrationTest.java
@@ -9,8 +9,7 @@ import com.food.common.user.domain.User;
 import com.food.mock.order.MockOrderFactory;
 import com.food.mock.payment.MockPaymentFactory;
 import com.food.mock.payment.MockPaymentLogFactory;
-import com.food.mock.store.MockStoreFactory;
-import com.food.mock.store.MockStoreOwnerFactory;
+import com.food.mock.store.*;
 import com.food.mock.user.MockAccountFactory;
 import com.food.mock.user.MockPointFactory;
 import com.food.mock.user.MockUserFactory;
@@ -36,6 +35,9 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
         MockPointFactory.class,
         MockStoreOwnerFactory.class,
         MockStoreFactory.class,
+        MockMenuFactory.class,
+        MockMenuOptionFactory.class,
+        MockMenuSelectionFactory.class,
         MockOrderFactory.class,
         MockPaymentFactory.class,
         MockPaymentLogFactory.class
@@ -68,6 +70,15 @@ public class SuperIntegrationTest {
 
     @Autowired
     protected MockStoreFactory storeFactory;
+
+    @Autowired
+    protected MockMenuFactory menuFactory;
+
+    @Autowired
+    protected MockMenuOptionFactory menuOptionFactory;
+
+    @Autowired
+    protected MockMenuSelectionFactory menuSelectionFactory;
 
     @Autowired
     protected MockOrderFactory orderFactory;

--- a/app/src/test/java/com/food/api/order/OrderApiTests.java
+++ b/app/src/test/java/com/food/api/order/OrderApiTests.java
@@ -1,0 +1,118 @@
+package com.food.api.order;
+
+import com.food.SuperIntegrationTest;
+import com.food.common.menu.domain.Menu;
+import com.food.common.menu.domain.MenuOption;
+import com.food.common.menu.domain.MenuSelection;
+import com.food.common.menu.repository.MenuQueryRepositoryImpl;
+import com.food.common.order.business.external.model.OrderDoViewRequest;
+import com.food.common.store.domain.Store;
+import com.food.common.store.domain.StoreOwner;
+import com.food.common.store.enumeration.StoreOpenStatus;
+import com.food.common.user.domain.User;
+import com.food.mock.menu.MockMenu;
+import com.food.mock.menu.MockMenuOption;
+import com.food.mock.menu.MockMenuSelection;
+import com.food.mock.store.MockStore;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class OrderApiTests extends SuperIntegrationTest {
+
+    private final String DOCUMENT_AUTH = "payment/do-order/";
+
+    private StoreOwner mockStoreOwner;
+
+    @Autowired
+    private MenuQueryRepositoryImpl menuQueryRepository;
+
+    @Autowired
+    private JPAQueryFactory queryFactory;
+
+    @BeforeEach
+    void setup() {
+        User storeOwnerUser = userFactory.user("i'm a storeowner");
+        mockStoreOwner = storeOwnerFactory.storeOwner(storeOwnerUser);
+    }
+
+    @Test
+    void shouldBeSuccessResult_whenRequestOrder() throws Exception {
+        //given
+        //운영중인 가게를 등록한다.
+        Store mockStore = storeFactory.store(MockStore.builder()
+                .owner(mockStoreOwner)
+                .status(StoreOpenStatus.OPEN)
+                .minOrderAmount(15000)
+                .name("떡볶이 참 잘하는 집")
+                .build());
+
+        //2가지 메뉴를 등록한다.
+        Menu mockMenu1 = menuFactory.menu(MockMenu.builder()
+                .store(mockStore)
+                .amount(12000)
+                .cookingTime(20)
+                .name("바질 떡볶이")
+                .build());
+
+        MenuOption mockOptionOfMenu1 = menuOptionFactory.menuOption(MockMenuOption.builder()
+                .menu(mockMenu1)
+                .name("매운맛 선택")
+                .minSize((byte) 1)
+                .maxSize((byte) 1)
+                .build());
+
+        List<MenuSelection> mockMenuSelections = menuSelectionFactory.menuSelections(
+                MockMenuSelection.builder()
+                        .option(mockOptionOfMenu1)
+                        .selection("순한맛")
+                        .amount(0)
+                        .build(),
+                MockMenuSelection.builder()
+                        .option(mockOptionOfMenu1)
+                        .selection("중간맛")
+                        .amount(0)
+                        .build(),
+                MockMenuSelection.builder()
+                        .option(mockOptionOfMenu1)
+                        .selection("매운맛")
+                        .amount(0)
+                        .build());
+
+
+        Menu mockMenu2 = menuFactory.menu(MockMenu.builder()
+                .store(mockStore)
+                .amount(3000)
+                .cookingTime(10)
+                .name("주먹밥")
+                .build());
+
+        //주문 요청 Request
+        OrderDoViewRequest.MenuOptionRequest menuOptionRequest = new OrderDoViewRequest.MenuOptionRequest(mockOptionOfMenu1.getId(), List.of(mockMenuSelections.get(1).getOptionId()));
+        OrderDoViewRequest.MenuRequest menuRequest1 = new OrderDoViewRequest.MenuRequest(mockMenu1.getId(), (byte) 1, List.of(menuOptionRequest));
+        OrderDoViewRequest.MenuRequest menuRequest2 = new OrderDoViewRequest.MenuRequest(mockMenu2.getId(), (byte) 1, null);
+
+        OrderDoViewRequest request = new OrderDoViewRequest(mockStore.getId(), List.of(menuRequest1, menuRequest2), "맛있게 해주세요.");
+
+        //when & then
+        mvc.perform(post("/api/orders")
+                .header(ACCEPT, APPLICATION_JSON_VALUE)
+                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .header(AUTHORIZATION, createAuthentication())
+                .characterEncoding("utf-8")
+                .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("success").value(true));
+    }
+}

--- a/app/src/test/java/com/food/mock/menu/MockMenuOption.java
+++ b/app/src/test/java/com/food/mock/menu/MockMenuOption.java
@@ -1,0 +1,51 @@
+package com.food.mock.menu;
+
+import com.food.common.menu.domain.Menu;
+import com.food.common.menu.domain.MenuOption;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+public class MockMenuOption {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @NoArgsConstructor(access = PRIVATE)
+    public static class Builder {
+        private Long id;
+        private Menu menu = MockMenu.builder().build();
+        private String name = "사리 추가";
+        private Byte minSize = 0;
+        private Byte maxSize = 3;
+
+        public Builder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder menu(Menu menu) {
+            this.menu = menu;
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder minSize(Byte minSize) {
+            this.minSize = minSize;
+            return this;
+        }
+
+        public Builder maxSize(Byte maxSize) {
+            this.maxSize = maxSize;
+            return this;
+        }
+
+        public MenuOption build() {
+            return MenuOption.create(menu, name, minSize, maxSize);
+        }
+    }
+}

--- a/app/src/test/java/com/food/mock/menu/MockMenuSelection.java
+++ b/app/src/test/java/com/food/mock/menu/MockMenuSelection.java
@@ -1,0 +1,45 @@
+package com.food.mock.menu;
+
+import com.food.common.menu.domain.MenuOption;
+import com.food.common.menu.domain.MenuSelection;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+public class MockMenuSelection {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @NoArgsConstructor(access = PRIVATE)
+    public static class Builder {
+        private Long id;
+        private MenuOption option = MockMenuOption.builder().build();
+        private String selection = "우동 사리";
+        private Integer amount = 2000;
+
+        public Builder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder option(MenuOption option) {
+            this.option = option;
+            return this;
+        }
+
+        public Builder selection(String selection) {
+            this.selection = selection;
+            return this;
+        }
+
+        public Builder amount(Integer amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public MenuSelection build() {
+            return MenuSelection.create(option, selection, amount);
+        }
+    }
+}

--- a/app/src/test/java/com/food/mock/store/MockMenuFactory.java
+++ b/app/src/test/java/com/food/mock/store/MockMenuFactory.java
@@ -1,0 +1,21 @@
+package com.food.mock.store;
+
+import com.food.common.menu.domain.Menu;
+import com.food.common.menu.repository.MenuRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+public class MockMenuFactory {
+
+    @Autowired
+    private MenuRepository menuRepository;
+
+    /****************************************************************************
+     * Create
+     ***************************************************************************/
+
+    public Menu menu(Menu menu) {
+        return menuRepository.save(menu);
+    }
+}

--- a/app/src/test/java/com/food/mock/store/MockMenuOptionFactory.java
+++ b/app/src/test/java/com/food/mock/store/MockMenuOptionFactory.java
@@ -1,0 +1,21 @@
+package com.food.mock.store;
+
+import com.food.common.menu.domain.MenuOption;
+import com.food.common.menu.repository.MenuOptionRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+public class MockMenuOptionFactory {
+
+    @Autowired
+    private MenuOptionRepository menuOptionRepository;
+
+    /****************************************************************************
+     * Create
+     ***************************************************************************/
+
+    public MenuOption menuOption(MenuOption menuOption) {
+        return menuOptionRepository.save(menuOption);
+    }
+}

--- a/app/src/test/java/com/food/mock/store/MockMenuSelectionFactory.java
+++ b/app/src/test/java/com/food/mock/store/MockMenuSelectionFactory.java
@@ -1,0 +1,23 @@
+package com.food.mock.store;
+
+import com.food.common.menu.domain.MenuSelection;
+import com.food.common.menu.repository.MenuSelectionRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
+
+import java.util.List;
+
+@TestComponent
+public class MockMenuSelectionFactory {
+
+    @Autowired
+    private MenuSelectionRepository menuSelectionRepository;
+
+    /****************************************************************************
+     * Create
+     ***************************************************************************/
+
+    public List<MenuSelection> menuSelections(MenuSelection... menuSelections) {
+        return menuSelectionRepository.saveAll(List.of(menuSelections));
+    }
+}

--- a/app/src/test/java/com/food/mock/store/MockStore.java
+++ b/app/src/test/java/com/food/mock/store/MockStore.java
@@ -2,6 +2,7 @@ package com.food.mock.store;
 
 import com.food.common.store.domain.Store;
 import com.food.common.store.domain.StoreOwner;
+import com.food.common.store.enumeration.StoreOpenStatus;
 import com.food.mock.user.MockUser;
 
 public class MockStore {
@@ -18,7 +19,7 @@ public class MockStore {
                 .build())
                 .build();
         private Integer minOrderAmount = 10000;
-        private Store.OpenStatus status = Store.OpenStatus.OPEN;
+        private StoreOpenStatus status = StoreOpenStatus.OPEN;
 
         public Builder id(Long id) {
             this.id = id;
@@ -40,7 +41,7 @@ public class MockStore {
             return this;
         }
 
-        public Builder status(Store.OpenStatus status) {
+        public Builder status(StoreOpenStatus status) {
             this.status = status;
             return this;
         }

--- a/app/src/test/java/com/food/mock/store/MockStoreFactory.java
+++ b/app/src/test/java/com/food/mock/store/MockStoreFactory.java
@@ -23,4 +23,8 @@ public class MockStoreFactory {
 
         return storeRepository.save(store);
     }
+
+    public Store store(Store store) {
+        return storeRepository.save(store);
+    }
 }

--- a/app/src/test/resources/schema.sql
+++ b/app/src/test/resources/schema.sql
@@ -76,6 +76,23 @@ create table tb_menu
     cooking_time mediumint not null
 );
 
+create table tb_menu_option
+(
+    menu_option_id bigint auto_increment primary key,
+    menu_id bigint not null,
+    name varchar(50) not null,
+    min_size tinyint not null,
+    max_size tinyint not null
+);
+
+create table tb_menu_selection
+(
+    menu_selection_id bigint auto_increment primary key,
+    menu_option_id bigint not null,
+    selection varchar(50) not null,
+    amount tinyint not null
+);
+
 create table tb_food_category
 (
     food_category_id bigint auto_increment primary key,

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -38,14 +38,23 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <!-- QueryDSL APT Config -->
+        <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-apt</artifactId>
+            <version>${querydsl.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- QueryDSL JPA Config -->
+        <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-jpa</artifactId>
+            <version>${querydsl.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.8.9</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -53,4 +62,24 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mysema.maven</groupId>
+                <artifactId>apt-maven-plugin</artifactId>
+                <version>1.1.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>target/generated-sources/java</outputDirectory>
+                            <processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/common/src/main/java/com/food/common/config/QuerydslConfig.java
+++ b/common/src/main/java/com/food/common/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.food.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/common/src/main/java/com/food/common/menu/business/internal/MenuCommonService.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/MenuCommonService.java
@@ -1,0 +1,9 @@
+package com.food.common.menu.business.internal;
+
+import com.food.common.menu.business.internal.dto.MenuDto;
+
+import java.util.List;
+
+public interface MenuCommonService {
+    List<MenuDto> findMenusInIds(List<Long> ids);
+}

--- a/common/src/main/java/com/food/common/menu/business/internal/dto/MenuDto.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/dto/MenuDto.java
@@ -1,11 +1,8 @@
 package com.food.common.menu.business.internal.dto;
 
 import com.food.common.menu.domain.Menu;
-import com.food.common.menu.domain.MenuOption;
 import lombok.Getter;
-import org.springframework.util.CollectionUtils;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,15 +15,13 @@ public final class MenuDto {
     private final Integer cookingTime;
     private final List<MenuOptionDto> options;
 
-    public MenuDto(Menu menuEntity, List<MenuOption> menuOptionEntities) {
+    public MenuDto(Menu menuEntity) {
         id = menuEntity.getId();
         storeId = menuEntity.getStoreId();
         name = menuEntity.getName();
         amount = menuEntity.getAmount();
         cookingTime = menuEntity.getCookingTime();
-        options = CollectionUtils.isEmpty(menuOptionEntities) ?
-                Collections.emptyList() :
-                menuOptionEntities.stream()
+        options = menuEntity.getOptions().stream()
                 .map(MenuOptionDto::new)
                 .collect(Collectors.toList());
     }

--- a/common/src/main/java/com/food/common/menu/business/internal/dto/MenuDto.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/dto/MenuDto.java
@@ -1,0 +1,41 @@
+package com.food.common.menu.business.internal.dto;
+
+import com.food.common.menu.domain.Menu;
+import com.food.common.menu.domain.MenuOption;
+import lombok.Getter;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public final class MenuDto {
+    private final Long id;
+    private final Long storeId;
+    private final String name;
+    private final Integer amount;
+    private final Integer cookingTime;
+    private final List<MenuOptionDto> options;
+
+    public MenuDto(Menu menuEntity, List<MenuOption> menuOptionEntities) {
+        id = menuEntity.getId();
+        storeId = menuEntity.getStoreId();
+        name = menuEntity.getName();
+        amount = menuEntity.getAmount();
+        cookingTime = menuEntity.getCookingTime();
+        options = CollectionUtils.isEmpty(menuOptionEntities) ?
+                Collections.emptyList() :
+                menuOptionEntities.stream()
+                .map(MenuOptionDto::new)
+                .collect(Collectors.toList());
+    }
+
+
+    public MenuOptionDto getOptionById(Long optionId) {
+        return options.stream()
+                .filter(option -> option.hasSameIdAs(optionId))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 선택옵션입니다."));
+    }
+}

--- a/common/src/main/java/com/food/common/menu/business/internal/dto/MenuOptionDto.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/dto/MenuOptionDto.java
@@ -1,0 +1,39 @@
+package com.food.common.menu.business.internal.dto;
+
+import com.food.common.menu.domain.MenuOption;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public final class MenuOptionDto {
+    private final Long id;
+    private final Long menuId;
+    private final String name;
+    private final Byte minSize;
+    private final Byte maxSize;
+    private final List<MenuSelectionDto> selections;
+
+    public MenuOptionDto(MenuOption entity) {
+        id = entity.getId();
+        menuId = entity.getMenuId();
+        name = entity.getName();
+        minSize = entity.getMinSize();
+        maxSize = entity.getMaxSize();
+        selections = entity.getSelections()
+                .stream().map(MenuSelectionDto::new)
+                .collect(Collectors.toList());
+    }
+
+    public MenuSelectionDto getSelection(Long selectionId) {
+        return selections.stream()
+                .filter(selection -> selection.hasSameIdAs(selectionId))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 선택지입니다."));
+    }
+
+    public boolean hasSameIdAs(Long optionId) {
+        return id.equals(optionId);
+    }
+}

--- a/common/src/main/java/com/food/common/menu/business/internal/dto/MenuSelectionDto.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/dto/MenuSelectionDto.java
@@ -1,0 +1,23 @@
+package com.food.common.menu.business.internal.dto;
+
+import com.food.common.menu.domain.MenuSelection;
+import lombok.Getter;
+
+@Getter
+public final class MenuSelectionDto {
+    private final Long id;
+    private final Long optionId;
+    private final String selection;
+    private final Integer amount;
+
+    public MenuSelectionDto(MenuSelection entity) {
+        id = entity.getId();
+        optionId = entity.getOptionId();
+        selection = entity.getSelection();
+        amount = entity.getAmount();
+    }
+
+    public boolean hasSameIdAs(Long id) {
+        return this.id.equals(id);
+    }
+}

--- a/common/src/main/java/com/food/common/menu/business/internal/impl/DefaultMenuCommonService.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/impl/DefaultMenuCommonService.java
@@ -1,0 +1,48 @@
+package com.food.common.menu.business.internal.impl;
+
+import com.food.common.menu.business.internal.MenuCommonService;
+import com.food.common.menu.business.internal.dto.MenuDto;
+import com.food.common.menu.domain.Menu;
+import com.food.common.menu.domain.MenuOption;
+import com.food.common.menu.repository.MenuOptionRepository;
+import com.food.common.menu.repository.MenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class DefaultMenuCommonService implements MenuCommonService {
+    private final MenuRepository menuRepository;
+    private final MenuOptionRepository menuOptionRepository;
+
+    public List<MenuDto> findMenusInIds(List<Long> ids) {
+        List<Menu> menus = menuRepository.findMenusByIdIn(ids);
+        validateMenus(menus, ids);
+
+        List<MenuOption> menuOptions = menuOptionRepository.findMenuOptionsByMenuIdIn(ids);
+
+        Map<Long, List<MenuOption>> menuOptionMap = menuOptions.stream()
+                .collect(Collectors.groupingBy(MenuOption::getMenuId, Collectors.toList()));
+
+        return menus.stream()
+                .map(menu -> new MenuDto(menu, menuOptionMap.get(menu.getId())))
+                .collect(Collectors.toList());
+    }
+
+    private void validateMenus(List<Menu> menus, List<Long> findMenuIds) {
+        if (CollectionUtils.isEmpty(menus)) {
+            throw new IllegalArgumentException("메뉴를 찾을 수 없습니다.");
+        }
+
+        if (menus.size() != findMenuIds.size()) {
+            throw new IllegalArgumentException("메뉴를 모두 찾을 수 없습니다.");
+        }
+    }
+}

--- a/common/src/main/java/com/food/common/menu/business/internal/impl/DefaultMenuCommonService.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/impl/DefaultMenuCommonService.java
@@ -3,8 +3,6 @@ package com.food.common.menu.business.internal.impl;
 import com.food.common.menu.business.internal.MenuCommonService;
 import com.food.common.menu.business.internal.dto.MenuDto;
 import com.food.common.menu.domain.Menu;
-import com.food.common.menu.domain.MenuOption;
-import com.food.common.menu.repository.MenuOptionRepository;
 import com.food.common.menu.repository.MenuRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -20,19 +17,13 @@ import java.util.stream.Collectors;
 @Service
 public class DefaultMenuCommonService implements MenuCommonService {
     private final MenuRepository menuRepository;
-    private final MenuOptionRepository menuOptionRepository;
 
     public List<MenuDto> findMenusInIds(List<Long> ids) {
         List<Menu> menus = menuRepository.findMenusByIdIn(ids);
         validateMenus(menus, ids);
 
-        List<MenuOption> menuOptions = menuOptionRepository.findMenuOptionsByMenuIdIn(ids);
-
-        Map<Long, List<MenuOption>> menuOptionMap = menuOptions.stream()
-                .collect(Collectors.groupingBy(MenuOption::getMenuId, Collectors.toList()));
-
         return menus.stream()
-                .map(menu -> new MenuDto(menu, menuOptionMap.get(menu.getId())))
+                .map(MenuDto::new)
                 .collect(Collectors.toList());
     }
 

--- a/common/src/main/java/com/food/common/menu/business/internal/impl/MenuEntityService.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/impl/MenuEntityService.java
@@ -1,0 +1,37 @@
+package com.food.common.menu.business.internal.impl;
+
+import com.food.common.menu.domain.Menu;
+import com.food.common.menu.repository.MenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MenuEntityService {
+    private final MenuRepository menuRepository;
+
+    public Map<Long, Menu> findAllByIdIn(List<Long> menuIds) {
+        List<Menu> menus = menuRepository.findMenusByIdIn(menuIds);
+
+        Map<Long, Menu> result = menus.stream()
+                .collect(Collectors.toMap(Menu::getId, Function.identity()));
+        validate(menuIds, result);
+
+        return result;
+    }
+
+    private void validate(List<Long> keys, Map<Long, Menu> findResult) {
+        for (Long key : keys) {
+            if (!findResult.containsKey(key)) {
+                throw new IllegalArgumentException("Menu를 찾을 수 없습니다. menuId=" + key);
+            }
+        }
+    }
+}

--- a/common/src/main/java/com/food/common/menu/domain/Menu.java
+++ b/common/src/main/java/com/food/common/menu/domain/Menu.java
@@ -1,6 +1,7 @@
 package com.food.common.menu.domain;
 
 import com.food.common.store.domain.Store;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 import org.hibernate.validator.constraints.Length;
@@ -10,10 +11,14 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PositiveOrZero;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+@Getter
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "tb_menu")
 @Entity
@@ -43,6 +48,9 @@ public class Menu {
     @NotNull
     private Integer cookingTime;
 
+    @OneToMany(mappedBy = "menu")
+    private final List<MenuOption> options = new ArrayList<>();
+
     public static Menu create(Store store, String name, Integer amount, Integer cookingTime) {
         Menu menu = new Menu();
         menu.store = store;
@@ -51,5 +59,13 @@ public class Menu {
         menu.cookingTime = cookingTime;
 
         return menu;
+    }
+
+    public void initOptions(List<MenuOption> options) {
+        this.options.addAll(options);
+    }
+
+    public Long getStoreId() {
+        return store.getId();
     }
 }

--- a/common/src/main/java/com/food/common/menu/domain/Menu.java
+++ b/common/src/main/java/com/food/common/menu/domain/Menu.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.util.CollectionUtils;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
@@ -12,6 +13,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PositiveOrZero;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static javax.persistence.FetchType.LAZY;
@@ -67,5 +69,9 @@ public class Menu {
 
     public Long getStoreId() {
         return store.getId();
+    }
+
+    public List<MenuOption> getOptions() {
+        return CollectionUtils.isEmpty(options) ? Collections.emptyList() : options;
     }
 }

--- a/common/src/main/java/com/food/common/menu/domain/MenuOption.java
+++ b/common/src/main/java/com/food/common/menu/domain/MenuOption.java
@@ -1,23 +1,26 @@
 package com.food.common.menu.domain;
 
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 import org.hibernate.validator.constraints.Length;
 
 import javax.persistence.*;
+import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+@Getter
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "tb_menu_option")
-@Entity
+@Entity(name = "MenuOption")
 public class MenuOption {
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -36,19 +39,19 @@ public class MenuOption {
     private String name;
 
     @Comment("최소 선택 개수")
-    @Size(max = 100)
+    @Max(100)
     @NotNull
     private Byte minSize;
 
     @Comment("최대 선택 개수")
-    @Size(max = 100)
+    @Max(100)
     @NotNull
     private Byte maxSize;
 
     @OneToMany(mappedBy = "option")
-    private final List<MenuSelection> selections = new ArrayList<>();
+    private List<MenuSelection> selections = new ArrayList<>();
 
-    public static MenuOption menuOption(Menu menu, String name, Byte minSize, Byte maxSize) {
+    public static MenuOption create(Menu menu, String name, Byte minSize, Byte maxSize) {
         MenuOption menuOption = new MenuOption();
         menuOption.menu = menu;
         menuOption.name = name;
@@ -56,5 +59,17 @@ public class MenuOption {
         menuOption.maxSize = maxSize;
 
         return menuOption;
+    }
+
+    public Long getMenuId() {
+        return menu.getId();
+    }
+
+    public void initSelections(List<MenuSelection> selections) {
+        this.selections.addAll(selections);
+    }
+
+    public List<MenuSelection> getSelections() {
+        return Collections.unmodifiableList(selections);
     }
 }

--- a/common/src/main/java/com/food/common/menu/domain/MenuOption.java
+++ b/common/src/main/java/com/food/common/menu/domain/MenuOption.java
@@ -8,6 +8,8 @@ import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
 
 import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
@@ -42,6 +44,9 @@ public class MenuOption {
     @Size(max = 100)
     @NotNull
     private Byte maxSize;
+
+    @OneToMany(mappedBy = "option")
+    private final List<MenuSelection> selections = new ArrayList<>();
 
     public static MenuOption menuOption(Menu menu, String name, Byte minSize, Byte maxSize) {
         MenuOption menuOption = new MenuOption();

--- a/common/src/main/java/com/food/common/menu/domain/MenuSelection.java
+++ b/common/src/main/java/com/food/common/menu/domain/MenuSelection.java
@@ -1,5 +1,6 @@
 package com.food.common.menu.domain;
 
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 import org.hibernate.validator.constraints.Length;
@@ -12,9 +13,10 @@ import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+@Getter
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "tb_menu_selection")
-@Entity
+@Entity(name = "MenuSelection")
 public class MenuSelection {
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -43,5 +45,9 @@ public class MenuSelection {
         menuSelection.amount = amount;
 
         return menuSelection;
+    }
+
+    public Long getOptionId() {
+        return option.getId();
     }
 }

--- a/common/src/main/java/com/food/common/menu/repository/MenuOptionRepository.java
+++ b/common/src/main/java/com/food/common/menu/repository/MenuOptionRepository.java
@@ -2,16 +2,6 @@ package com.food.common.menu.repository;
 
 import com.food.common.menu.domain.MenuOption;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface MenuOptionRepository extends JpaRepository<MenuOption, Long> {
-
-    @Query("select option " +
-            "from MenuOption option " +
-            "left join fetch option.selections " +
-            "where option.menu.id in (:menuIds)")
-    List<MenuOption> findMenuOptionsByMenuIdIn(@Param("menuIds") List<Long> menuIds);
 }

--- a/common/src/main/java/com/food/common/menu/repository/MenuOptionRepository.java
+++ b/common/src/main/java/com/food/common/menu/repository/MenuOptionRepository.java
@@ -2,6 +2,16 @@ package com.food.common.menu.repository;
 
 import com.food.common.menu.domain.MenuOption;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MenuOptionRepository extends JpaRepository<MenuOption, Long> {
+
+    @Query("select option " +
+            "from MenuOption option " +
+            "left join fetch option.selections " +
+            "where option.menu.id in (:menuIds)")
+    List<MenuOption> findMenuOptionsByMenuIdIn(@Param("menuIds") List<Long> menuIds);
 }

--- a/common/src/main/java/com/food/common/menu/repository/MenuQueryRepository.java
+++ b/common/src/main/java/com/food/common/menu/repository/MenuQueryRepository.java
@@ -1,0 +1,9 @@
+package com.food.common.menu.repository;
+
+import com.food.common.menu.domain.Menu;
+
+import java.util.List;
+
+public interface MenuQueryRepository {
+    List<Menu> findMenusByIdIn(List<Long> menuIds);
+}

--- a/common/src/main/java/com/food/common/menu/repository/MenuQueryRepositoryImpl.java
+++ b/common/src/main/java/com/food/common/menu/repository/MenuQueryRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.food.common.menu.repository;
+
+import com.food.common.menu.domain.Menu;
+import com.food.common.menu.domain.MenuOption;
+import com.food.common.menu.domain.MenuSelection;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.food.common.menu.domain.QMenu.menu;
+import static com.food.common.menu.domain.QMenuOption.menuOption;
+import static com.food.common.menu.domain.QMenuSelection.menuSelection;
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+
+@RequiredArgsConstructor
+@Repository
+public class MenuQueryRepositoryImpl implements MenuQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Menu> findMenusByIdIn(List<Long> menuIds) {
+        List<Menu> result = queryFactory
+                .selectFrom(menu)
+                .where(menu.id.in(menuIds))
+                .fetch();
+
+        Map<Long, List<MenuOption>> menuOptionsMap = findMenuOptionsByMenuIdIn(menuIds);
+        result.forEach(menu -> {
+            if (menuOptionsMap.containsKey(menu.getId())) {
+                menu.initOptions(menuOptionsMap.get(menu.getId()));
+            }
+        });
+
+        return result;
+    }
+
+    private Map<Long, List<MenuOption>> findMenuOptionsByMenuIdIn(List<Long> menuIds) {
+        Map<MenuOption, List<MenuSelection>> optionsMap = queryFactory
+                .selectFrom(menuOption)
+                .leftJoin(menuOption.selections, menuSelection)
+                .where(menuOption.menu.id.in(menuIds))
+                .transform(groupBy(menuOption).as(list(menuSelection)));
+
+
+        Map<Long, List<MenuOption>> result = new HashMap<>();
+        for (MenuOption option : optionsMap.keySet()) {
+            option.initSelections(optionsMap.get(option));
+
+            List<MenuOption> value = result.getOrDefault(option.getMenuId(), new ArrayList<>());
+            value.add(option);
+            result.put(option.getMenuId(), value);
+        }
+
+        return result;
+    }
+}

--- a/common/src/main/java/com/food/common/menu/repository/MenuRepository.java
+++ b/common/src/main/java/com/food/common/menu/repository/MenuRepository.java
@@ -3,5 +3,9 @@ package com.food.common.menu.repository;
 import com.food.common.menu.domain.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+    List<Menu> findMenusByIdIn(List<Long> menuIds);
 }

--- a/common/src/main/java/com/food/common/menu/repository/MenuRepository.java
+++ b/common/src/main/java/com/food/common/menu/repository/MenuRepository.java
@@ -3,9 +3,5 @@ package com.food.common.menu.repository;
 import com.food.common.menu.domain.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
-public interface MenuRepository extends JpaRepository<Menu, Long> {
-
-    List<Menu> findMenusByIdIn(List<Long> menuIds);
+public interface MenuRepository extends JpaRepository<Menu, Long>, MenuQueryRepository {
 }

--- a/common/src/main/java/com/food/common/order/business/external/OrderService.java
+++ b/common/src/main/java/com/food/common/order/business/external/OrderService.java
@@ -1,0 +1,12 @@
+package com.food.common.order.business.external;
+
+import com.food.common.order.business.external.model.OrderDoViewRequest;
+import com.food.common.user.business.external.model.RequestUser;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
+
+@Validated
+public interface OrderService {
+    Long order(@NotNull OrderDoViewRequest request, @NotNull RequestUser requestUser);
+}

--- a/common/src/main/java/com/food/common/order/business/external/model/OrderDoViewRequest.java
+++ b/common/src/main/java/com/food/common/order/business/external/model/OrderDoViewRequest.java
@@ -1,0 +1,82 @@
+package com.food.common.order.business.external.model;
+
+import lombok.Getter;
+import org.springframework.util.CollectionUtils;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Validated
+public class OrderDoViewRequest {
+    @NotNull @Positive
+    private final Long storeId;
+    @NotNull @Size(min = 1)
+    private final List<MenuRequest> menus;
+    private final String comment;
+
+    public OrderDoViewRequest(Long storeId, List<MenuRequest> menus, String comment) {
+        this.storeId = storeId;
+        this.menus = menus;
+        this.comment = comment;
+    }
+
+    public Long getStoreId() {
+        return storeId;
+    }
+
+    public List<Long> getMenuIds() {
+        return menus.stream()
+                .map(menu -> menu.menuId)
+                .collect(Collectors.toList());
+    }
+
+    public MenuRequest getMenuById(Long menuId) {
+        return menus.stream()
+                .filter(menu -> menu.menuId.equals(menuId))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("메뉴 주문내역이 존재하지 않습니다."));
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    @Getter
+    public static class MenuRequest {
+        @NotNull @Positive
+        private final Long menuId;
+        @NotNull @Positive @Max(100)
+        private final Byte count;
+        private final List<MenuOptionRequest> options;
+
+        public MenuRequest(Long menuId, Byte count, List<MenuOptionRequest> options) {
+            this.menuId = menuId;
+            this.count = count;
+            this.options = options;
+        }
+
+        public List<MenuOptionRequest> getOptions() {
+            return CollectionUtils.isEmpty(options) ? Collections.emptyList() : options;
+        }
+    }
+
+    @Getter
+    public static class MenuOptionRequest {
+        @NotNull @Positive
+        private final Long optionId;
+
+        @NotNull @Size(min = 1)
+        private final List<Long> selectionIds;
+
+        public MenuOptionRequest(Long optionId, List<Long> selectionIds) {
+            this.optionId = optionId;
+            this.selectionIds = selectionIds;
+        }
+    }
+}

--- a/common/src/main/java/com/food/common/order/business/internal/OrderCommonService.java
+++ b/common/src/main/java/com/food/common/order/business/internal/OrderCommonService.java
@@ -1,10 +1,13 @@
 package com.food.common.order.business.internal;
 
 import com.food.common.order.business.internal.dto.OrderDto;
+import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 import java.util.Optional;
 
+@Validated
 public interface OrderCommonService {
-    Optional<OrderDto> findById(@NotNull Long id);
+    Optional<OrderDto> findById(@NotNull @Positive Long id);
 }

--- a/common/src/main/java/com/food/common/order/business/internal/OrderCommonService.java
+++ b/common/src/main/java/com/food/common/order/business/internal/OrderCommonService.java
@@ -1,6 +1,6 @@
 package com.food.common.order.business.internal;
 
-import com.food.common.order.business.internal.dto.OrderDto;
+import com.food.common.order.business.model.OrderDto;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.NotNull;

--- a/common/src/main/java/com/food/common/order/business/internal/OrderCommonService.java
+++ b/common/src/main/java/com/food/common/order/business/internal/OrderCommonService.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 @Validated
 public interface OrderCommonService {
     Optional<OrderDto> findById(@NotNull @Positive Long id);
+
+    Long save(OrderDto order);
 }

--- a/common/src/main/java/com/food/common/order/business/internal/OrderMenuCommonService.java
+++ b/common/src/main/java/com/food/common/order/business/internal/OrderMenuCommonService.java
@@ -1,0 +1,9 @@
+package com.food.common.order.business.internal;
+
+import com.food.common.order.business.internal.dto.OrderMenuDto;
+
+import java.util.List;
+
+public interface OrderMenuCommonService {
+    List<OrderMenuDto> saveAll(Long orderId, List<OrderMenuDto> orderMenus);
+}

--- a/common/src/main/java/com/food/common/order/business/internal/OrderMenuCommonService.java
+++ b/common/src/main/java/com/food/common/order/business/internal/OrderMenuCommonService.java
@@ -1,6 +1,6 @@
 package com.food.common.order.business.internal;
 
-import com.food.common.order.business.internal.dto.OrderMenuDto;
+import com.food.common.order.business.model.OrderMenuDto;
 
 import java.util.List;
 

--- a/common/src/main/java/com/food/common/order/business/internal/dto/OrderDto.java
+++ b/common/src/main/java/com/food/common/order/business/internal/dto/OrderDto.java
@@ -23,4 +23,13 @@ public final class OrderDto {
         this.status = order.getStatus();
         this.comment = order.getComment();
     }
+
+    public OrderDto(Long customerId, Long storeId, Integer amount, OrderStatus status, String comment) {
+        this.id = null;
+        this.customerId = customerId;
+        this.storeId = storeId;
+        this.amount = amount;
+        this.status = status;
+        this.comment = comment;
+    }
 }

--- a/common/src/main/java/com/food/common/order/business/internal/dto/OrderMenuDto.java
+++ b/common/src/main/java/com/food/common/order/business/internal/dto/OrderMenuDto.java
@@ -1,0 +1,33 @@
+package com.food.common.order.business.internal.dto;
+
+import com.food.common.order.domain.OrderMenu;
+import lombok.Getter;
+
+@Getter
+public final class OrderMenuDto {
+    private final Long id;
+    private final Long orderId;
+    private final Long menuId;
+    private final Integer amount;
+    private final Byte count;
+
+    public OrderMenuDto(OrderMenu entity) {
+        id = entity.getId();
+        orderId = entity.getOrderId();
+        menuId = entity.getMenuId();
+        amount = entity.getAmount();
+        count = entity.getCount();
+    }
+
+    public OrderMenuDto(Long menuId, Integer amount, Byte count) {
+        this.id = null;
+        this.orderId = null;
+        this.menuId = menuId;
+        this.amount = amount;
+        this.count = count;
+    }
+
+    public Long getMenuId() {
+        return menuId;
+    }
+}

--- a/common/src/main/java/com/food/common/order/business/internal/dto/OrderMenuSelectionDto.java
+++ b/common/src/main/java/com/food/common/order/business/internal/dto/OrderMenuSelectionDto.java
@@ -1,0 +1,13 @@
+package com.food.common.order.business.internal.dto;
+
+public class OrderMenuSelectionDto {
+    private final Long id;
+    private final Long menuId;
+    private final Long menuSelectionId;
+
+    public OrderMenuSelectionDto(Long menuId, Long menuSelectionId) {
+        this.id = null;
+        this.menuId = menuId;
+        this.menuSelectionId = menuSelectionId;
+    }
+}

--- a/common/src/main/java/com/food/common/order/business/internal/impl/DefaultOrderCommonService.java
+++ b/common/src/main/java/com/food/common/order/business/internal/impl/DefaultOrderCommonService.java
@@ -1,7 +1,7 @@
 package com.food.common.order.business.internal.impl;
 
 import com.food.common.order.business.internal.OrderCommonService;
-import com.food.common.order.business.internal.dto.OrderDto;
+import com.food.common.order.business.model.OrderDto;
 import com.food.common.order.domain.Order;
 import com.food.common.order.repository.OrderRepository;
 import com.food.common.store.business.internal.impl.StoreEntityService;

--- a/common/src/main/java/com/food/common/order/business/internal/impl/DefaultOrderCommonService.java
+++ b/common/src/main/java/com/food/common/order/business/internal/impl/DefaultOrderCommonService.java
@@ -4,6 +4,10 @@ import com.food.common.order.business.internal.OrderCommonService;
 import com.food.common.order.business.internal.dto.OrderDto;
 import com.food.common.order.domain.Order;
 import com.food.common.order.repository.OrderRepository;
+import com.food.common.store.business.internal.impl.StoreEntityService;
+import com.food.common.store.domain.Store;
+import com.food.common.user.business.internal.impl.UserEntityService;
+import com.food.common.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,6 +17,8 @@ import java.util.Optional;
 @Service
 public class DefaultOrderCommonService implements OrderCommonService {
     private final OrderRepository orderRepository;
+    private final StoreEntityService storeEntityService;
+    private final UserEntityService userEntityService;
 
     @Override
     public Optional<OrderDto> findById(Long id) {
@@ -23,5 +29,14 @@ public class DefaultOrderCommonService implements OrderCommonService {
         }
 
         return Optional.of(new OrderDto(optionalOrder.get()));
+    }
+
+    @Override
+    public Long save(OrderDto order) {
+        User customer = userEntityService.findById(order.getCustomerId());
+        Store store = storeEntityService.findById(order.getStoreId());
+
+        Order entity = Order.create(customer, store, order.getAmount(), order.getStatus(), order.getComment());
+        return orderRepository.save(entity).getId();
     }
 }

--- a/common/src/main/java/com/food/common/order/business/internal/impl/DefaultOrderMenuCommonService.java
+++ b/common/src/main/java/com/food/common/order/business/internal/impl/DefaultOrderMenuCommonService.java
@@ -3,7 +3,7 @@ package com.food.common.order.business.internal.impl;
 import com.food.common.menu.business.internal.impl.MenuEntityService;
 import com.food.common.menu.domain.Menu;
 import com.food.common.order.business.internal.OrderMenuCommonService;
-import com.food.common.order.business.internal.dto.OrderMenuDto;
+import com.food.common.order.business.model.OrderMenuDto;
 import com.food.common.order.domain.Order;
 import com.food.common.order.domain.OrderMenu;
 import com.food.common.order.repository.OrderMenuRepository;

--- a/common/src/main/java/com/food/common/order/business/internal/impl/DefaultOrderMenuCommonService.java
+++ b/common/src/main/java/com/food/common/order/business/internal/impl/DefaultOrderMenuCommonService.java
@@ -1,0 +1,48 @@
+package com.food.common.order.business.internal.impl;
+
+import com.food.common.menu.business.internal.impl.MenuEntityService;
+import com.food.common.menu.domain.Menu;
+import com.food.common.order.business.internal.OrderMenuCommonService;
+import com.food.common.order.business.internal.dto.OrderMenuDto;
+import com.food.common.order.domain.Order;
+import com.food.common.order.domain.OrderMenu;
+import com.food.common.order.repository.OrderMenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class DefaultOrderMenuCommonService implements OrderMenuCommonService {
+    private final OrderMenuRepository orderMenuRepository;
+    private final OrderEntityService orderEntityService;
+    private final MenuEntityService menuEntityService;
+
+    @Override
+    public List<OrderMenuDto> saveAll(Long orderId, List<OrderMenuDto> orderMenus) {
+        Order order = orderEntityService.findById(orderId);
+        Map<Long, Menu> menus = menuEntityService.findAllByIdIn(toMenuIds(orderMenus));
+
+        List<OrderMenu> savedEntities = orderMenuRepository.saveAll(toEntities(orderMenus, order, menus));
+        return savedEntities.stream()
+                .map(OrderMenuDto::new)
+                .collect(Collectors.toList());
+    }
+
+    private static List<OrderMenu> toEntities(List<OrderMenuDto> orderMenus, Order order, Map<Long, Menu> menus) {
+        return orderMenus.stream()
+                .map(orderMenu -> OrderMenu.create(order, menus.get(orderMenu.getMenuId()), orderMenu.getAmount(), orderMenu.getCount()))
+                .toList();
+    }
+
+    private List<Long> toMenuIds(List<OrderMenuDto> orderMenus) {
+        return orderMenus.stream()
+                .map(OrderMenuDto::getMenuId)
+                .collect(Collectors.toList());
+    }
+}

--- a/common/src/main/java/com/food/common/order/business/model/OrderDto.java
+++ b/common/src/main/java/com/food/common/order/business/model/OrderDto.java
@@ -1,4 +1,4 @@
-package com.food.common.order.business.internal.dto;
+package com.food.common.order.business.model;
 
 import com.food.common.order.enumeration.OrderStatus;
 import com.food.common.order.domain.Order;

--- a/common/src/main/java/com/food/common/order/business/model/OrderMenuDto.java
+++ b/common/src/main/java/com/food/common/order/business/model/OrderMenuDto.java
@@ -1,4 +1,4 @@
-package com.food.common.order.business.internal.dto;
+package com.food.common.order.business.model;
 
 import com.food.common.order.domain.OrderMenu;
 import lombok.Getter;

--- a/common/src/main/java/com/food/common/order/business/model/OrderMenuSelectionDto.java
+++ b/common/src/main/java/com/food/common/order/business/model/OrderMenuSelectionDto.java
@@ -1,4 +1,4 @@
-package com.food.common.order.business.internal.dto;
+package com.food.common.order.business.model;
 
 public class OrderMenuSelectionDto {
     private final Long id;

--- a/common/src/main/java/com/food/common/order/domain/OrderMenu.java
+++ b/common/src/main/java/com/food/common/order/domain/OrderMenu.java
@@ -1,6 +1,7 @@
 package com.food.common.order.domain;
 
 import com.food.common.menu.domain.Menu;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
@@ -14,6 +15,7 @@ import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+@Getter
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "tb_order_menu")
 @Entity
@@ -53,5 +55,13 @@ public class OrderMenu {
         orderMenu.count = count;
 
         return orderMenu;
+    }
+
+    public Long getOrderId() {
+        return order.getId();
+    }
+
+    public Long getMenuId() {
+        return menu.getId();
     }
 }

--- a/common/src/main/java/com/food/common/payment/business/external/model/PayRequest.java
+++ b/common/src/main/java/com/food/common/payment/business/external/model/PayRequest.java
@@ -1,6 +1,6 @@
 package com.food.common.payment.business.external.model;
 
-import com.food.common.order.business.internal.dto.OrderDto;
+import com.food.common.order.business.model.OrderDto;
 import com.food.common.payment.business.external.model.payrequest.PaymentElement;
 import com.food.common.payment.business.external.model.payrequest.PointPayment;
 import com.food.common.payment.enumeration.PaymentActionType;

--- a/common/src/main/java/com/food/common/store/business/internal/StoreCommonService.java
+++ b/common/src/main/java/com/food/common/store/business/internal/StoreCommonService.java
@@ -1,0 +1,11 @@
+package com.food.common.store.business.internal;
+
+import com.food.common.store.business.internal.dto.StoreDto;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import java.util.Optional;
+
+public interface StoreCommonService {
+    Optional<StoreDto> findById(@NotNull @Positive Long storeId);
+}

--- a/common/src/main/java/com/food/common/store/business/internal/StoreOwnerEntityService.java
+++ b/common/src/main/java/com/food/common/store/business/internal/StoreOwnerEntityService.java
@@ -1,4 +1,4 @@
-package com.food.common.store.business;
+package com.food.common.store.business.internal;
 
 import com.food.common.store.domain.StoreOwner;
 import com.food.common.user.domain.User;

--- a/common/src/main/java/com/food/common/store/business/internal/dto/StoreDto.java
+++ b/common/src/main/java/com/food/common/store/business/internal/dto/StoreDto.java
@@ -1,0 +1,22 @@
+package com.food.common.store.business.internal.dto;
+
+import com.food.common.store.domain.Store;
+import com.food.common.store.enumeration.StoreOpenStatus;
+import lombok.Getter;
+
+@Getter
+public final class StoreDto {
+    private final Long storeId;
+    private final String name;
+    private final Long storeOwnerId;
+    private final Integer minOrderAmount;
+    private final StoreOpenStatus openStatus;
+
+    public StoreDto(Store entity) {
+        this.storeId = entity.getId();
+        this.name = entity.getName();
+        this.storeOwnerId = entity.getOwnerId();
+        this.minOrderAmount = entity.getMinOrderAmount();
+        this.openStatus = entity.getStatus();
+    }
+}

--- a/common/src/main/java/com/food/common/store/business/internal/dto/StoreDto.java
+++ b/common/src/main/java/com/food/common/store/business/internal/dto/StoreDto.java
@@ -19,4 +19,8 @@ public final class StoreDto {
         this.minOrderAmount = entity.getMinOrderAmount();
         this.openStatus = entity.getStatus();
     }
+
+    public boolean isClosed() {
+        return openStatus == StoreOpenStatus.CLOSED;
+    }
 }

--- a/common/src/main/java/com/food/common/store/business/internal/impl/DefaultStoreCommonService.java
+++ b/common/src/main/java/com/food/common/store/business/internal/impl/DefaultStoreCommonService.java
@@ -1,0 +1,24 @@
+package com.food.common.store.business.internal.impl;
+
+import com.food.common.store.business.internal.StoreCommonService;
+import com.food.common.store.business.internal.dto.StoreDto;
+import com.food.common.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class DefaultStoreCommonService implements StoreCommonService {
+    private final StoreRepository storeRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public Optional<StoreDto> findById(Long storeId) {
+        return storeRepository.findById(storeId)
+                .map(StoreDto::new);
+    }
+}

--- a/common/src/main/java/com/food/common/store/business/internal/impl/DefaultStoreOwnerEntityService.java
+++ b/common/src/main/java/com/food/common/store/business/internal/impl/DefaultStoreOwnerEntityService.java
@@ -1,6 +1,6 @@
-package com.food.common.store.business.impl;
+package com.food.common.store.business.internal.impl;
 
-import com.food.common.store.business.StoreOwnerEntityService;
+import com.food.common.store.business.internal.StoreOwnerEntityService;
 import com.food.common.store.domain.StoreOwner;
 import com.food.common.user.domain.User;
 import com.food.common.user.repository.StoreOwnerRepository;

--- a/common/src/main/java/com/food/common/store/business/internal/impl/StoreEntityService.java
+++ b/common/src/main/java/com/food/common/store/business/internal/impl/StoreEntityService.java
@@ -1,0 +1,19 @@
+package com.food.common.store.business.internal.impl;
+
+import com.food.common.store.domain.Store;
+import com.food.common.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class StoreEntityService {
+    private final StoreRepository storeRepository;
+
+    public Store findById(Long id) {
+        return storeRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Store가 존재하지 않습니다. id=" + id));
+    }
+}

--- a/common/src/main/java/com/food/common/store/domain/Store.java
+++ b/common/src/main/java/com/food/common/store/domain/Store.java
@@ -1,5 +1,6 @@
 package com.food.common.store.domain;
 
+import com.food.common.store.enumeration.StoreOpenStatus;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
@@ -45,9 +46,9 @@ public class Store {
     @NotNull(message = OPEN_STATUS_CANNOT_BE_NULL)
     @Enumerated(STRING)
     @Column(name = "OPEN_STATUS")
-    private OpenStatus status;
+    private StoreOpenStatus status;
 
-    public static Store create(String name, StoreOwner owner, Integer minOrderAmount, OpenStatus status) {
+    public static Store create(String name, StoreOwner owner, Integer minOrderAmount, StoreOpenStatus status) {
         Store store = new Store();
         store.name = name;
         store.owner = owner;
@@ -55,18 +56,6 @@ public class Store {
         store.status = status;
 
         return store;
-    }
-
-    public enum OpenStatus {
-        OPEN("운영 중"),
-        CLOSED("운영 종료")
-        ;
-
-        private final String description;
-
-        OpenStatus(String description) {
-            this.description = description;
-        }
     }
 
 }

--- a/common/src/main/java/com/food/common/store/domain/Store.java
+++ b/common/src/main/java/com/food/common/store/domain/Store.java
@@ -58,4 +58,7 @@ public class Store {
         return store;
     }
 
+    public Long getOwnerId() {
+        return owner.getId();
+    }
 }

--- a/common/src/main/java/com/food/common/store/enumeration/StoreOpenStatus.java
+++ b/common/src/main/java/com/food/common/store/enumeration/StoreOpenStatus.java
@@ -1,0 +1,13 @@
+package com.food.common.store.enumeration;
+
+public enum StoreOpenStatus {
+    OPEN("운영 중"),
+    CLOSED("운영 종료")
+    ;
+
+    private final String description;
+
+    StoreOpenStatus(String description) {
+        this.description = description;
+    }
+}

--- a/common/src/main/java/com/food/common/user/business/internal/impl/DefaultUserCommonService.java
+++ b/common/src/main/java/com/food/common/user/business/internal/impl/DefaultUserCommonService.java
@@ -1,6 +1,6 @@
 package com.food.common.user.business.internal.impl;
 
-import com.food.common.store.business.StoreOwnerEntityService;
+import com.food.common.store.business.internal.StoreOwnerEntityService;
 import com.food.common.store.domain.StoreOwner;
 import com.food.common.user.business.internal.UserCommonService;
 import com.food.common.user.business.internal.dto.UserDto;

--- a/common/src/main/java/com/food/common/user/domain/LogInOutLog.java
+++ b/common/src/main/java/com/food/common/user/domain/LogInOutLog.java
@@ -50,7 +50,7 @@ public class LogInOutLog extends BaseTimeEntity {
         }
     }
 
-    private enum LogType {
+    public enum LogType {
         LOGIN,
         LOGOUT
     }

--- a/common/src/test/java/com/food/common/mock/store/MockStore.java
+++ b/common/src/test/java/com/food/common/mock/store/MockStore.java
@@ -3,6 +3,7 @@ package com.food.common.mock.store;
 import com.food.common.mock.user.MockUser;
 import com.food.common.store.domain.Store;
 import com.food.common.store.domain.StoreOwner;
+import com.food.common.store.enumeration.StoreOpenStatus;
 
 public class MockStore {
     public static Builder builder()  {
@@ -18,7 +19,7 @@ public class MockStore {
                 .build())
                 .build();
         private Integer minOrderAmount = 10000;
-        private Store.OpenStatus status = Store.OpenStatus.OPEN;
+        private StoreOpenStatus status = StoreOpenStatus.OPEN;
 
         public Builder id(Long id) {
             this.id = id;
@@ -40,7 +41,7 @@ public class MockStore {
             return this;
         }
 
-        public Builder status(Store.OpenStatus status) {
+        public Builder status(StoreOpenStatus status) {
             this.status = status;
             return this;
         }

--- a/common/src/test/java/com/food/common/unit/store/domain/StoreTests.java
+++ b/common/src/test/java/com/food/common/unit/store/domain/StoreTests.java
@@ -2,6 +2,7 @@ package com.food.common.unit.store.domain;
 
 import com.food.common.mock.store.MockStore;
 import com.food.common.store.domain.Store;
+import com.food.common.store.enumeration.StoreOpenStatus;
 import com.food.common.unit.SuperValidationTests;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -86,7 +87,7 @@ public class StoreTests extends SuperValidationTests<Store> {
                 .status(null)
                 .build();
 
-        Set<Store> mockStoresWithEnumTypeStatus = Arrays.stream(Store.OpenStatus.values()).map(
+        Set<Store> mockStoresWithEnumTypeStatus = Arrays.stream(StoreOpenStatus.values()).map(
                 status -> MockStore.builder()
                         .status(status)
                         .build()

--- a/order/src/main/java/com/food/order/business/DefaultOrderService.java
+++ b/order/src/main/java/com/food/order/business/DefaultOrderService.java
@@ -27,10 +27,8 @@ import java.util.List;
 public class DefaultOrderService implements OrderService {
     private final StoreCommonService storeCommonService;
     private final MenuCommonService menuCommonService;
-
     private final OrderCommonService orderCommonService;
     private final OrderMenuCommonService orderMenuCommonService;
-
 
     @Override
     public Long order(OrderDoViewRequest request, RequestUser requestUser) {

--- a/order/src/main/java/com/food/order/business/DefaultOrderService.java
+++ b/order/src/main/java/com/food/order/business/DefaultOrderService.java
@@ -1,0 +1,107 @@
+package com.food.order.business;
+
+import com.food.common.menu.business.internal.MenuCommonService;
+import com.food.common.menu.business.internal.dto.MenuDto;
+import com.food.common.menu.business.internal.dto.MenuOptionDto;
+import com.food.common.menu.business.internal.dto.MenuSelectionDto;
+import com.food.common.order.business.external.OrderService;
+import com.food.common.order.business.external.model.OrderDoViewRequest;
+import com.food.common.order.business.internal.OrderCommonService;
+import com.food.common.order.business.internal.OrderMenuCommonService;
+import com.food.common.store.business.internal.StoreCommonService;
+import com.food.common.store.business.internal.dto.StoreDto;
+import com.food.common.user.business.external.model.RequestUser;
+import com.food.order.business.model.Order;
+import com.food.order.business.model.OrderMenu;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class DefaultOrderService implements OrderService {
+    private final StoreCommonService storeCommonService;
+    private final MenuCommonService menuCommonService;
+
+    private final OrderCommonService orderCommonService;
+    private final OrderMenuCommonService orderMenuCommonService;
+
+
+    @Override
+    public Long order(OrderDoViewRequest request, RequestUser requestUser) {
+        StoreDto store = storeCommonService.findById(request.getStoreId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 가게입니다. storeId=" + request.getStoreId()));
+
+        if (store.isClosed()) {
+            throw new IllegalArgumentException(store.getName() + "은(는) 영업 종료되었습니다.");
+        }
+
+        List<MenuDto> menus = menuCommonService.findMenusInIds(request.getMenuIds());
+        validateMenus(menus, request);
+
+        List<OrderMenu> orderMenus = toOrderMenus(request, menus);
+        Order order = new Order(requestUser.getUserId(), store, orderMenus, request.getComment());
+
+        if (!order.hasGreaterTotalPriceThanMinOrderAmount()) {
+            throw new IllegalArgumentException("최소주문금액보다 적은 주문금액입니다.");
+        }
+
+        Long savedOrderId = orderCommonService.save(order.toOrderDto());
+        orderMenuCommonService.saveAll(savedOrderId, order.toOrderMenuDtos());
+        return null;
+    }
+
+    private List<OrderMenu> toOrderMenus(OrderDoViewRequest request, List<MenuDto> menus) {
+        List<OrderMenu> result = new ArrayList<>();
+        for (MenuDto menu : menus) {
+            OrderDoViewRequest.MenuRequest menuRequest = request.getMenuById(menu.getId());
+            List<OrderDoViewRequest.MenuOptionRequest> optionRequests = menuRequest.getOptions();
+
+            OrderMenu orderMenu = new OrderMenu(menu.getId(), menu.getAmount(), menuRequest.getCount(), toOrderMenuOptions(optionRequests, menu));
+            result.add(orderMenu);
+        }
+
+        return result;
+    }
+
+    private void validateMenus(List<MenuDto> menus, OrderDoViewRequest request) {
+        if (CollectionUtils.isEmpty(menus)) throw new IllegalArgumentException("주문 메뉴를 찾을 수 없습니다. ");
+
+        if (request.getMenuIds().size() != menus.size()) {
+            throw new IllegalArgumentException("존재하지 않는 주문메뉴가 포함되어 있습니다.");
+        }
+
+        boolean containMenusNotInOrderedStore = menus.stream().anyMatch(menu -> !menu.getStoreId().equals(request.getStoreId()));
+        if (containMenusNotInOrderedStore) {
+            throw new IllegalArgumentException("주문메뉴가 주문가게와 일치하지 않습니다.");
+        }
+    }
+
+    private List<OrderMenu.OrderMenuOption> toOrderMenuOptions(List<OrderDoViewRequest.MenuOptionRequest> requests, MenuDto menuDto) {
+        List<OrderMenu.OrderMenuOption> result = new ArrayList<>();
+        for (OrderDoViewRequest.MenuOptionRequest request : requests) {
+            MenuOptionDto menuOption = menuDto.getOptionById(request.getOptionId());
+
+            List<OrderMenu.OrderMenuSelection> orderMenuSelections = toOrderMenuSelections(request, menuOption);
+            result.add(new OrderMenu.OrderMenuOption(
+                    menuOption.getId(), menuOption.getMaxSize(), menuOption.getMinSize(), orderMenuSelections));
+        }
+
+        return result;
+    }
+
+    private List<OrderMenu.OrderMenuSelection> toOrderMenuSelections(OrderDoViewRequest.MenuOptionRequest optionRequest, MenuOptionDto optionDto) {
+        List<OrderMenu.OrderMenuSelection> result = new ArrayList<>();
+        for (Long selectionId : optionRequest.getSelectionIds()) {
+            MenuSelectionDto selection = optionDto.getSelection(selectionId);
+            result.add(new OrderMenu.OrderMenuSelection(selectionId, selection.getAmount()));
+        }
+
+        return result;
+    }
+}

--- a/order/src/main/java/com/food/order/business/DefaultPayService.java
+++ b/order/src/main/java/com/food/order/business/DefaultPayService.java
@@ -1,7 +1,7 @@
 package com.food.order.business;
 
 import com.food.common.order.business.internal.OrderCommonService;
-import com.food.common.order.business.internal.dto.OrderDto;
+import com.food.common.order.business.model.OrderDto;
 import com.food.common.payment.business.external.PayService;
 import com.food.common.payment.business.external.model.PayRequest;
 import com.food.common.payment.business.external.model.payrequest.PointPayment;

--- a/order/src/main/java/com/food/order/business/model/Order.java
+++ b/order/src/main/java/com/food/order/business/model/Order.java
@@ -1,7 +1,7 @@
 package com.food.order.business.model;
 
-import com.food.common.order.business.internal.dto.OrderDto;
-import com.food.common.order.business.internal.dto.OrderMenuDto;
+import com.food.common.order.business.model.OrderDto;
+import com.food.common.order.business.model.OrderMenuDto;
 import com.food.common.order.enumeration.OrderStatus;
 import com.food.common.store.business.internal.dto.StoreDto;
 import org.springframework.validation.annotation.Validated;

--- a/order/src/main/java/com/food/order/business/model/Order.java
+++ b/order/src/main/java/com/food/order/business/model/Order.java
@@ -1,0 +1,56 @@
+package com.food.order.business.model;
+
+import com.food.common.order.business.internal.dto.OrderDto;
+import com.food.common.order.business.internal.dto.OrderMenuDto;
+import com.food.common.order.enumeration.OrderStatus;
+import com.food.common.store.business.internal.dto.StoreDto;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Validated
+public class Order {
+    private final Long customerId;
+
+    @NotNull
+    private final StoreDto store;
+
+    private final OrderStatus status = OrderStatus.REQUEST;
+
+    @NotNull @Size(min = 1)
+    private final List<OrderMenu> menus;
+
+    private final String comment;
+
+    private Long savedOrderId;
+
+    public Order(Long customerId, StoreDto store, List<OrderMenu> menus, String comment) {
+        this.customerId = customerId;
+        this.store = store;
+        this.menus = menus;
+        this.comment = comment;
+    }
+
+    public boolean hasGreaterTotalPriceThanMinOrderAmount() {
+        return orderAmount() >= store.getMinOrderAmount();
+    }
+
+    public Integer orderAmount() {
+        return menus.stream()
+                .map(OrderMenu::getOrderMenuAmount)
+                .reduce(0, Integer::sum);
+    }
+
+    public OrderDto toOrderDto() {
+        return new OrderDto(customerId, store.getStoreId(), orderAmount(), status, comment);
+    }
+
+    public List<OrderMenuDto> toOrderMenuDtos() {
+        return menus.stream()
+                .map(OrderMenu::toOrderMenuDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/order/src/main/java/com/food/order/business/model/OrderMenu.java
+++ b/order/src/main/java/com/food/order/business/model/OrderMenu.java
@@ -1,0 +1,77 @@
+package com.food.order.business.model;
+
+import com.food.common.order.business.internal.dto.OrderMenuDto;
+import lombok.Builder;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+public class OrderMenu {
+    private Long menuId;
+    private Integer amount;
+    private Byte count;
+    private List<OrderMenuOption> options;
+
+    @Builder
+    public OrderMenu(Long menuId, Integer menuAmount, Byte count, List<OrderMenuOption> options) {
+        this.menuId = menuId;
+        this.amount = menuAmount;
+        this.count = count;
+        this.options = options == null ? Collections.emptyList() : options;
+    }
+
+    public Integer getOrderMenuAmount() {
+        return (amount + totalExtraAmountOfOptions()) * count;
+    }
+
+    public Integer totalExtraAmountOfOptions() {
+        return options.stream()
+                .map(OrderMenuOption::totalAmountOfSelections)
+                .reduce(0, Integer::sum);
+    }
+
+    public OrderMenuDto toOrderMenuDto() {
+        return new OrderMenuDto(menuId, amount, count);
+    }
+
+    public static class OrderMenuOption {
+        private Long id;
+
+        private Byte maxSize;
+
+        private Byte minSize;
+
+        private List<OrderMenuSelection> selections;
+
+        public OrderMenuOption(Long optionId, Byte maxSize, Byte minSize, List<OrderMenuSelection> selections) {
+            this.id = optionId;
+            this.maxSize = maxSize;
+            this.minSize = minSize;
+            this.selections = selections;
+            validate();
+        }
+
+        private void validate() {
+            if (CollectionUtils.isEmpty(selections)) throw new IllegalArgumentException("");
+            if (selections.size() < minSize) throw new IllegalArgumentException("최소 선택개수보다 적습니다.");
+            if (maxSize < selections.size()) throw new IllegalArgumentException("최대 선택개수보다 더 많습니다.");
+        }
+
+        public Integer totalAmountOfSelections() {
+            return selections.stream()
+                    .map(selection -> selection.amount)
+                    .reduce(0, Integer::sum);
+        }
+    }
+
+    public static class OrderMenuSelection {
+        private Long id;
+        private Integer amount;
+
+        public OrderMenuSelection(Long selectionId, Integer amount) {
+            this.id = selectionId;
+            this.amount = amount;
+        }
+    }
+}

--- a/order/src/main/java/com/food/order/business/model/OrderMenu.java
+++ b/order/src/main/java/com/food/order/business/model/OrderMenu.java
@@ -1,6 +1,6 @@
 package com.food.order.business.model;
 
-import com.food.common.order.business.internal.dto.OrderMenuDto;
+import com.food.common.order.business.model.OrderMenuDto;
 import lombok.Builder;
 import org.springframework.util.CollectionUtils;
 

--- a/order/src/main/java/com/food/order/presentation/OrderController.java
+++ b/order/src/main/java/com/food/order/presentation/OrderController.java
@@ -1,0 +1,33 @@
+package com.food.order.presentation;
+
+import com.food.common.annotation.ApiFor;
+import com.food.common.annotation.Authenticated;
+import com.food.common.apiResult.SuccessResult;
+import com.food.common.order.business.external.OrderService;
+import com.food.common.user.business.external.model.RequestUser;
+import com.food.common.user.enumeration.Role;
+import com.food.common.order.business.external.model.OrderDoViewRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@ApiFor(roles = Role.CUSTOMER)
+@RequiredArgsConstructor
+@RequestMapping("/api/orders")
+@RestController
+public class OrderController {
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<SuccessResult> order(@Authenticated RequestUser requestUser,
+                                               @RequestBody OrderDoViewRequest request) {
+
+        orderService.order(request, requestUser);
+
+        return ResponseEntity.ok(SuccessResult.createResult());
+    }
+
+}

--- a/order/src/main/java/com/food/order/presentation/PayController.java
+++ b/order/src/main/java/com/food/order/presentation/PayController.java
@@ -36,15 +36,4 @@ public class PayController {
 
         return ResponseEntity.ok(SuccessResult.createResult());
     }
-
-    /**
-     * TODO
-     * Order 조리 사직인지 확인 (요청중일 때만 취소가능)
-     * Order에 상태 변경 (취소)
-     * Payment 상태 변경 (v)
-     * 사용 Point 취소 (v)
-     * 적립 Point 회수 (v)
-     */
-
-
 }


### PR DESCRIPTION
### 내용 
* Querydsl 의존성 추가 
* 주문하기 API 구현 (`/api/orders`)
* Order, Store, Menu 등 DB 데이터 조회용 CommonService 생성
* Menu : MenuOption (1:N 관계) /  MenuOption : MenuSelection (1:N관계) 에 대한 조회용 MenuQueryRepository 생성 (Querydsl 사용)
* 테스트 환경 - Menu, MenuOption, MenuSelection 엔티티에 대한 Mock 객체 및 테스트 객체 생성 클래스 생성
* 테스트 환경 - 주문하기 API 성공 테스트케이스 추가

--- 
View Request(`OrderDoViewRequest.java`) 객체와 비즈니스 모델(`OrderMenu.java`)을 나누었지만 OrderService 내에서 이를 매핑하는 과정이 조금 복잡하게 만든 것 같아 추가 리팩토링이 필요할 것 같습니다! 변경파일 양이 많아 먼저 PR 올립니다~!  
  
_레파지토리 변경으로 인해 진행중인 [PR](https://github.com/f-lab-edu/food-service/pull/26)을 같은 내용으로 올립니다~!_