### PR TITLE
결제 상세 로그의 사용포인트의 PointId 반영 구현

### DIFF
--- a/common/src/main/java/com/food/common/payment/business/external/model/payrequest/PaymentElement.java
+++ b/common/src/main/java/com/food/common/payment/business/external/model/payrequest/PaymentElement.java
@@ -3,6 +3,7 @@ package com.food.common.payment.business.external.model.payrequest;
 import com.food.common.payment.enumeration.PaymentMethod;
 
 import javax.validation.constraints.NotNull;
+import java.util.Optional;
 
 public abstract class PaymentElement {
     @NotNull
@@ -24,5 +25,9 @@ public abstract class PaymentElement {
             case ACCOUNT_TRANSFER -> new AccountTransferPayment(amount);
             case POINT -> new PointPayment(amount);
         };
+    }
+
+    public Optional<Long> getPointId() {
+        return Optional.empty();
     }
 }

--- a/common/src/main/java/com/food/common/payment/business/external/model/payrequest/PointPayment.java
+++ b/common/src/main/java/com/food/common/payment/business/external/model/payrequest/PointPayment.java
@@ -2,11 +2,10 @@ package com.food.common.payment.business.external.model.payrequest;
 
 import com.food.common.payment.enumeration.PaymentMethod;
 import com.food.common.user.business.external.model.PointUseRequest;
-import lombok.Getter;
 
 import javax.validation.constraints.NotNull;
+import java.util.Optional;
 
-@Getter
 public final class PointPayment extends PaymentElement {
     private Long pointId;
 
@@ -30,7 +29,12 @@ public final class PointPayment extends PaymentElement {
         return PaymentMethod.POINT;
     }
 
-    public void validate() {
+    public Optional<Long> getPointId() {
+        validateNotNullPointId();
+        return Optional.of(pointId);
+    }
+
+    private void validateNotNullPointId() {
         if (pointId == null) {
             throw new IllegalArgumentException("포인트 지급내역이 존재하지 않습니다.");
         }

--- a/common/src/main/java/com/food/common/payment/domain/PaymentLog.java
+++ b/common/src/main/java/com/food/common/payment/domain/PaymentLog.java
@@ -6,6 +6,7 @@ import com.food.common.user.domain.Point;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+import org.springframework.validation.annotation.Validated;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -17,6 +18,7 @@ import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+@Validated
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "tb_payment_log")
@@ -63,8 +65,8 @@ public class PaymentLog extends BaseTimeEntity {
         return create(null, payment, method, amount, null);
     }
 
-    public static PaymentLog create(Payment payment, PaymentMethod method, Integer amount, Point point) {
-        return create(null, payment, method, amount, point);
+    public void update(@NotNull Point point) {
+        this.point = point;
     }
 
     public Long getPaymentId() {

--- a/common/src/test/java/com/food/common/mock/payment/MockPaymentLog.java
+++ b/common/src/test/java/com/food/common/mock/payment/MockPaymentLog.java
@@ -3,7 +3,6 @@ package com.food.common.mock.payment;
 import com.food.common.mock.user.MockPoint;
 import com.food.common.payment.domain.Payment;
 import com.food.common.payment.domain.PaymentLog;
-import com.food.common.payment.enumeration.PaymentActionType;
 import com.food.common.payment.enumeration.PaymentMethod;
 import com.food.common.user.domain.Point;
 
@@ -16,7 +15,6 @@ public class MockPaymentLog {
         private Long id;
         private Payment payment = MockPayment.builder().build();
         private PaymentMethod method = PaymentMethod.CARD;
-        private PaymentActionType type = PaymentActionType.PAYMENT;
         private Integer amount = 24000;
         private Point point = MockPoint.builder().build();
 
@@ -27,11 +25,6 @@ public class MockPaymentLog {
 
         public Builder payment(Payment payment) {
             this.payment = payment;
-            return this;
-        }
-
-        public Builder actionType(PaymentActionType type) {
-            this.type = type;
             return this;
         }
 
@@ -51,7 +44,7 @@ public class MockPaymentLog {
         }
 
         public PaymentLog build() {
-            return PaymentLog.create(payment, method, amount, point);
+            return PaymentLog.create(payment, method, amount);
         }
     }
 }

--- a/order/src/main/java/com/food/order/presentation/dto/request/PaymentDoRequest.java
+++ b/order/src/main/java/com/food/order/presentation/dto/request/PaymentDoRequest.java
@@ -61,19 +61,6 @@ public class PaymentDoRequest {
         return Collections.unmodifiableList(items);
     }
 
-    public boolean hasItemWithPointMethod() {
-        return items.stream()
-                .anyMatch(item -> item.getMethod() == PaymentMethod.POINT);
-    }
-
-    public int getUsedPointAmount() {
-        return items.stream()
-                .filter(item -> item.getMethod() == PaymentMethod.POINT)
-                .map(Item::getAmount)
-                .findAny()
-                .orElse(0);
-    }
-
     @Getter
     public static class Item {
         private final PaymentMethod method;

--- a/order/src/test/java/com/food/order/PaymentDoTest.java
+++ b/order/src/test/java/com/food/order/PaymentDoTest.java
@@ -87,7 +87,7 @@ public class PaymentDoTest {
     @Test
     void 주문서의_금액과_결제금액이_일치하지_않으면_실패한다() {
         //given
-        OrderDto mockOrder = stubOrderService.save(MockOrder.create(30_000));
+        OrderDto mockOrder = savedMockOrder(30_000);
 
         PaymentDoRequest.Item requestItem = new PaymentDoRequest.Item(PaymentMethod.CARD, 40_000);
         PaymentDoRequest request = new PaymentDoRequest(mockOrder.getId(), requestItem);
@@ -106,7 +106,7 @@ public class PaymentDoTest {
     @Test
     void 중복_결제데이터가_존재하면_실패한다() {
         //given
-        OrderDto mockOrder = stubOrderService.save(MockOrder.create());
+        OrderDto mockOrder = savedMockOrder();
         stubPaymentService.save(MockPayment.create(mockOrder));
 
         PaymentDoRequest.Item requestItem = new PaymentDoRequest.Item(PaymentMethod.CARD, mockOrder.getAmount());
@@ -122,7 +122,7 @@ public class PaymentDoTest {
     @Test
     void 결제데이터와_디테일로그데이터를_저장한다() {
         //given
-        OrderDto mockOrder = stubOrderService.save(MockOrder.create());
+        OrderDto mockOrder = savedMockOrder();
 
         PaymentDoRequest.Item requestItem1 = new PaymentDoRequest.Item(PaymentMethod.CARD, 10_000);
         PaymentDoRequest.Item requestItem2 = new PaymentDoRequest.Item(PaymentMethod.ACCOUNT_TRANSFER, mockOrder.getAmount() - 10_000);
@@ -161,6 +161,23 @@ public class PaymentDoTest {
         PaymentLogDto pointPaymentLog = paymentLogs2.get(0);
         assertEquals(savedPaymentId2, pointPaymentLog.getPaymentId());
         assertNotNull(pointPaymentLog.getPointId());
+    }
+
+//    @Test
+//    void 결제가_완료되면_포인트사용금액을_제외한_총금액으로_포인트적립_요청한다() {
+//        OrderDto mockOrder = stubOrderService.save(MockOrder.create());
+//        PaymentDoRequest.Item requestItem1 = new PaymentDoRequest.Item(PaymentMethod.CARD, 10_000);
+//
+//
+//        assertTrue(stubPointService.isCalledToCollect());
+//    }
+
+    private OrderDto savedMockOrder(int amount) {
+        return stubOrderService.save(MockOrder.create(amount));
+    }
+
+    private OrderDto savedMockOrder() {
+        return stubOrderService.save(MockOrder.create());
     }
 
     private int getTotalAmountOfPaymentLogs(List<PaymentLogDto> paymentLogs) {

--- a/order/src/test/java/com/food/order/stubrepository/StubPaymentLogService.java
+++ b/order/src/test/java/com/food/order/stubrepository/StubPaymentLogService.java
@@ -39,6 +39,7 @@ public class StubPaymentLogService implements PaymentLogCommonService {
                     .paymentId(paymentId)
                     .method(element.method())
                     .amount(element.getAmount())
+                    .pointId(element.getPointId().orElse(null))
                     .build();
 
             save(paymentLogDto);

--- a/order/src/test/java/com/food/order/stubrepository/StubPointService.java
+++ b/order/src/test/java/com/food/order/stubrepository/StubPointService.java
@@ -8,6 +8,7 @@ public class StubPointService implements PointService {
     private boolean calledToUsePoints = false;
     private boolean calledToCollectPoints = false;
     private Long autoIncrementKey = -1L;
+    private Integer collectedAmount;
 
     public boolean isCalledToCollect() {
         return calledToCollectPoints;
@@ -15,6 +16,10 @@ public class StubPointService implements PointService {
 
     public boolean isCalledToUse() {
         return calledToUsePoints;
+    }
+
+    public Integer getCollectedAmount() {
+        return collectedAmount;
     }
 
     @Override
@@ -27,6 +32,7 @@ public class StubPointService implements PointService {
     @Override
     public void collect(PointCollectRequest request) {
         calledToCollectPoints = true;
+        collectedAmount = request.getPaymentAmount();
     }
 
     @Override

--- a/order/src/test/java/com/food/order/temp/DefaultPayService.java
+++ b/order/src/test/java/com/food/order/temp/DefaultPayService.java
@@ -3,6 +3,7 @@ package com.food.order.temp;
 import com.food.common.order.business.internal.OrderCommonService;
 import com.food.common.order.business.internal.dto.OrderDto;
 import com.food.common.payment.business.external.model.payrequest.PaymentElement;
+import com.food.common.payment.business.external.model.payrequest.PointPayment;
 import com.food.common.payment.business.internal.PaymentCommonService;
 import com.food.common.payment.business.internal.PaymentLogCommonService;
 import com.food.common.payment.business.internal.model.PaymentDto;
@@ -46,21 +47,27 @@ public class DefaultPayService implements PayService {
                 .build();
         Long paymentId = paymentCommonService.save(paymentDto).getId();
 
-        usePoints(request, requestUser);
-
-        Set<PaymentElement> paymentElements = request.getItems().stream()
-                .map(item -> PaymentElement.findPaymentElement(item.getMethod(), item.getAmount()))
-                .collect(Collectors.toSet());
+        Set<PaymentElement> paymentElements = getPaymentElements(request, requestUser);
         paymentLogRepository.saveAll(paymentId, paymentElements);
 
         return paymentId;
     }
 
-    private void usePoints(PaymentDoRequest request, RequestUser requestUser) {
-        if (request.hasItemWithPointMethod()) {
-            PointUseRequest pointUseRequest = new PointUseRequest(request.getUsedPointAmount(), requestUser.getUserId());
+    private Set<PaymentElement> getPaymentElements(PaymentDoRequest request, RequestUser requestUser) {
+        return request.getItems().stream()
+                .map(item -> {
+                    PaymentElement element = PaymentElement.findPaymentElement(item.getMethod(), item.getAmount());
+                    usePointsIfPaymentMethodIsPoint(requestUser, element);
 
-            pointService.use(pointUseRequest);
+                    return element;
+                })
+                .collect(Collectors.toSet());
+    }
+
+    private void usePointsIfPaymentMethodIsPoint(RequestUser requestUser, PaymentElement element) {
+        if (element instanceof PointPayment pointPayment) {
+            PointUseRequest pointUseRequest = new PointUseRequest(pointPayment.getAmount(), requestUser.getUserId());
+            pointPayment.updateUsedPointId(pointService.use(pointUseRequest));
         }
     }
 }


### PR DESCRIPTION
### 결제하기 기능 요구사항
- [x] 결제 금액, 결제수단과 함께 통보한다.
- [x]  결제 금액과 결제수단은 필수값이다.
- [x]  결제 시 두개 이상의 결제 수단으로 요청할 수 있다. (포인트, 카드, 계좌이체)
- [x]  DB에 결제요청한 주문서가 존재해야한다 (MSG: 유효하지 않은 주문서입니다.)
- [x]  주문서의 금액과 총 결제금액이 일치해야한다. (MSG: 잘못된 결제금액입니다.)
- [x]  중복 결제내역이 있으면 안된다.
- [x]  결제수단에 포인트가 존재하면 잔여포인트를 차감한다. (잔여포인트가 충분해야한다. MSG: 잔여포인트가 부족합니다.) (point service 호출)
- [x]  DB에 결제 내역과 로그가 저장되어야한다.
- [x]  **결제가 완료되면 포인트가 적립된다. (point service 호출)**
- [x]  Repository 직접 호출 로직을 제거하고, 공통 모듈을 통해 간접호출하도록 리팩토링한다.
- [x]  service 기능구현 완료하면 주석 작성한다.

### 리뷰노트
* 결제수단별로 하위 클래스로 분리 되어있다.
```
   * PaymentElement (부모)
      * CardElement (자식)
      * AccountTransferElement (자식)
      * PointElement (자식) -> 이 클래스에만 pointId 필드를 소유하고 있다.
```
   * 결제수단이 포인트일 경우 PointId를 알아내기 위해 클라이언트 로직에서 부모객체인 `PaymentElement`에게 `PointElement` 여부를 묻는 조건문이 늘어나 결국 PaymentElement 내부에 결제수단이 포인트일 경우에만 존재하는 `Optional<Long> getPointId()` 메서드를 생성하였다.
   * PaymentElement 네이밍 다시 정해야한다.