### PR TITLE
결제 취소 기능 유효성 검증 추가

### DIFF
--- a/common/src/main/java/com/food/common/payment/business/internal/PaymentCommonService.java
+++ b/common/src/main/java/com/food/common/payment/business/internal/PaymentCommonService.java
@@ -4,6 +4,7 @@ import com.food.common.payment.business.internal.model.PaymentDto;
 import com.food.common.payment.enumeration.PaymentActionType;
 
 import javax.validation.constraints.NotNull;
+import java.util.Optional;
 
 public interface PaymentCommonService {
     /**
@@ -21,4 +22,11 @@ public interface PaymentCommonService {
      * @return 데이터 존재 유무
      */
     boolean existsById(@NotNull Long id);
+
+    /**
+     * ID로 결제데이터를 리턴한다.
+     * @param id 결제 ID. null일 수 없다.
+     * @return 주어진 ID를 보유한 결제데이터 또는 찾을 수 없는 경우 Optional#empty()
+     */
+    Optional<PaymentDto> findById(@NotNull Long id);
 }

--- a/common/src/main/java/com/food/common/payment/business/internal/impl/DefaultPaymentCommonService.java
+++ b/common/src/main/java/com/food/common/payment/business/internal/impl/DefaultPaymentCommonService.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Transactional
 @Service
@@ -37,5 +39,11 @@ public class DefaultPaymentCommonService implements PaymentCommonService {
     @Override
     public boolean existsById(Long id) {
         return paymentRepository.existsById(id);
+    }
+
+    @Override
+    public Optional<PaymentDto> findById(Long id) {
+        return paymentRepository.findById(id)
+                .map(PaymentDto::new);
     }
 }

--- a/common/src/main/java/com/food/common/payment/business/internal/model/PaymentDto.java
+++ b/common/src/main/java/com/food/common/payment/business/internal/model/PaymentDto.java
@@ -23,4 +23,8 @@ public final class PaymentDto {
         orderId = payment.getOrder().getId();
         actionType = payment.getActionType();
     }
+
+    public boolean isCanceled() {
+        return actionType == PaymentActionType.CANCELLATION;
+    }
 }

--- a/order/src/main/java/com/food/order/error/PaymentErrors.java
+++ b/order/src/main/java/com/food/order/error/PaymentErrors.java
@@ -7,7 +7,9 @@ import lombok.AllArgsConstructor;
 public enum PaymentErrors implements ApplicationErrors {
     INVALID_PAYMENT_PARAMETERS("PAYMENT_0001", "유효하지 않은 파라미터 요청으로 인해 결제를 수행할 수 없습니다."),
     WRONG_PAYMENT_AMOUNT("PAYMENT_0002", "결제금액이 주문금액과 동일하지 않습니다."),
-    ALREADY_EXISTS_PAYMENT_FOR_ORDER("PAYMENT_0003", "해당 주문서에 대한 결제내역이 존재합니다.")
+    ALREADY_EXISTS_PAYMENT_FOR_ORDER("PAYMENT_0003", "해당 주문서에 대한 결제내역이 존재합니다."),
+    NOT_FOUND_PAYMENT("PAYMENT_0004", "결제정보를 찾을 수 없습니다."),
+    INVALID_ACTION_TYPE("PAYMENT_0005", "적합하지 않은 액션타입의 결제정보입니다."),
     ;
 
     private final String code;

--- a/order/src/test/java/com/food/order/PaymentCancelTest.java
+++ b/order/src/test/java/com/food/order/PaymentCancelTest.java
@@ -1,0 +1,95 @@
+package com.food.order;
+
+import com.food.common.payment.business.internal.model.PaymentDto;
+import com.food.common.payment.enumeration.PaymentActionType;
+import com.food.order.mock.MockRequestUser;
+import com.food.order.stubrepository.StubOrderService;
+import com.food.order.stubrepository.StubPaymentLogService;
+import com.food.order.stubrepository.StubPaymentService;
+import com.food.order.stubrepository.StubPointService;
+import com.food.order.temp.DefaultPayService;
+import com.food.order.temp.InvalidPaymentActionTypeException;
+import com.food.order.temp.NotFoundPaymentException;
+import com.food.order.temp.PayService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PaymentCancelTest {
+    /**
+     * 요청정보인 PaymentId의 결제정보가 존재해야한다. (v)
+     * 결제 정보의 ActionType이 '취소'이면 취소처리에 실패한다. (v)
+     * 결제 정보의 상태를 '취소'로 변경한다.
+     * 포인트 사용 금액이 있다면 재적립한다.
+     * 포인트 적립 금액이 있다면 회수한다.
+     */
+
+    private PayService payService;
+    private StubOrderService stubOrderService;
+    private StubPaymentService stubPaymentService;
+    private StubPaymentLogService stubPaymentLogService;
+    private StubPointService stubPointService;
+    private MockRequestUser mockRequestUser;
+
+    @BeforeEach
+    void setup() {
+        stubOrderService = new StubOrderService();
+        stubPaymentService = new StubPaymentService();
+        stubPaymentLogService = new StubPaymentLogService();
+        stubPointService = new StubPointService();
+        mockRequestUser = new MockRequestUser(1L);
+
+        payService = new DefaultPayService(stubOrderService, stubPaymentService, stubPaymentLogService, stubPointService);
+    }
+
+    @Test
+    void paymentId의_결제정보가_존재하지_않으면_예외가_발생한다() {
+        //given
+        Long paymentId = givenPaymentIdNotPresent();
+
+        //when & then
+        NotFoundPaymentException error = assertThrows(NotFoundPaymentException.class, () -> payService.cancel(paymentId, mockRequestUser));
+        assertTrue(error.getMessage().contains("paymentId="+paymentId));
+
+        //given & when & then
+        assertDoesNotThrow(() -> payService.cancel(givenPaymentIdPresent(), mockRequestUser));
+    }
+
+    private Long givenPaymentIdNotPresent() {
+        Long result = 1L;
+        boolean exists = stubPaymentService.existsById(result);
+        if (exists) {
+            throw new IllegalArgumentException();
+        }
+
+        return result;
+    }
+
+    private Long givenPaymentIdPresent() {
+        PaymentDto payment = PaymentDto.builder()
+                .build();
+        return stubPaymentService.save(payment).getId();
+    }
+
+    @Test
+    void paymentId의_결제정보의_actionType이_이미_취소상태이면_예외가_발생한다() {
+        //given
+        PaymentDto paymentCanceled = PaymentDto.builder()
+                .actionType(PaymentActionType.CANCELLATION)
+                .build();
+        Long paymentId1 = stubPaymentService.save(paymentCanceled).getId();
+
+        //when & then
+        assertThrows(InvalidPaymentActionTypeException.class, () -> payService.cancel(paymentId1, mockRequestUser));
+
+        //given
+        PaymentDto paymentNotCanceled = PaymentDto.builder()
+                .actionType(PaymentActionType.PAYMENT)
+                .build();
+        Long paymentId2 = stubPaymentService.save(paymentNotCanceled).getId();
+
+        //when & then
+        assertDoesNotThrow(() -> payService.cancel(paymentId2, mockRequestUser));
+    }
+}

--- a/order/src/test/java/com/food/order/stubrepository/StubPaymentService.java
+++ b/order/src/test/java/com/food/order/stubrepository/StubPaymentService.java
@@ -6,6 +6,7 @@ import com.food.common.payment.enumeration.PaymentActionType;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class StubPaymentService implements PaymentCommonService {
     private final Map<Long, PaymentDto> data = new HashMap<>();
@@ -34,5 +35,10 @@ public class StubPaymentService implements PaymentCommonService {
     @Override
     public boolean existsById(Long id) {
         return data.containsKey(id);
+    }
+
+    @Override
+    public Optional<PaymentDto> findById(Long id) {
+        return Optional.ofNullable(data.get(id));
     }
 }

--- a/order/src/test/java/com/food/order/temp/DefaultPayService.java
+++ b/order/src/test/java/com/food/order/temp/DefaultPayService.java
@@ -17,6 +17,7 @@ import com.food.order.error.DuplicatedPaymentException;
 import com.food.order.error.InvalidPaymentException;
 import com.food.order.error.NotFoundOrderException;
 import com.food.order.error.PaymentErrors;
+import com.food.order.mock.MockRequestUser;
 import com.food.order.presentation.dto.request.PaymentDoRequest;
 import lombok.RequiredArgsConstructor;
 
@@ -85,5 +86,15 @@ public class DefaultPayService implements PayService {
                 .filter(element -> element.method() != PaymentMethod.POINT)
                 .mapToInt(PaymentElement::getAmount)
                 .sum();
+    }
+
+    @Override
+    public void cancel(Long paymentId, MockRequestUser mockRequestUser) {
+        PaymentDto payment = paymentCommonService.findById(paymentId)
+                .orElseThrow(() -> new NotFoundPaymentException(paymentId));
+
+        if (payment.isCanceled()) {
+            throw new InvalidPaymentActionTypeException("이미 취소된 주문정보입니다.");
+        }
     }
 }

--- a/order/src/test/java/com/food/order/temp/InvalidPaymentActionTypeException.java
+++ b/order/src/test/java/com/food/order/temp/InvalidPaymentActionTypeException.java
@@ -1,0 +1,11 @@
+package com.food.order.temp;
+
+import com.food.order.error.PaymentErrors;
+
+public class InvalidPaymentActionTypeException extends RuntimeException {
+    private static final PaymentErrors ERROR = PaymentErrors.INVALID_ACTION_TYPE;
+
+    public InvalidPaymentActionTypeException(String detailMessage) {
+        super(ERROR.appendMessage(detailMessage));
+    }
+}

--- a/order/src/test/java/com/food/order/temp/NotFoundPaymentException.java
+++ b/order/src/test/java/com/food/order/temp/NotFoundPaymentException.java
@@ -1,0 +1,11 @@
+package com.food.order.temp;
+
+import com.food.order.error.PaymentErrors;
+
+public class NotFoundPaymentException extends RuntimeException {
+    private static final PaymentErrors ERROR = PaymentErrors.NOT_FOUND_PAYMENT;
+
+    public NotFoundPaymentException(Long paymentId) {
+        super(ERROR.appendMessage("paymentId=" + paymentId));
+    }
+}

--- a/order/src/test/java/com/food/order/temp/PayService.java
+++ b/order/src/test/java/com/food/order/temp/PayService.java
@@ -1,8 +1,11 @@
 package com.food.order.temp;
 
 import com.food.common.user.business.external.model.RequestUser;
+import com.food.order.mock.MockRequestUser;
 import com.food.order.presentation.dto.request.PaymentDoRequest;
 
 public interface PayService {
     Long pay(PaymentDoRequest request, RequestUser requestUser);
+
+    void cancel(Long paymentId, MockRequestUser mockRequestUser);
 }


### PR DESCRIPTION
결제 취소 요구사항
- [x] **요청정보인 PaymentId의 결제정보가 존재해야한다.**
- [x] **결제 정보의 ActionType이 '취소'이면 취소처리에 실패한다.**
- [ ] 결제 정보의 상태를 '취소'로 변경한다.
- [ ] 포인트 사용 금액이 있다면 재적립한다.
- [ ] 포인트 적립 금액이 있다면 회수한다.

### 리뷰 노트
* TDD방식으로 기능 재구현
* 유효성 검증 일부만 추가하였다.
