### PR TITLE
주문 기능 및 가게 조회 기능 일부 유효성 검증 추가

### DIFF
--- a/app/src/test/java/com/food/mock/store/MockStore.java
+++ b/app/src/test/java/com/food/mock/store/MockStore.java
@@ -2,6 +2,7 @@ package com.food.mock.store;
 
 import com.food.common.store.domain.Store;
 import com.food.common.store.domain.StoreOwner;
+import com.food.common.store.domain.type.OpenStatus;
 import com.food.mock.user.MockUser;
 
 public class MockStore {
@@ -18,7 +19,7 @@ public class MockStore {
                 .build())
                 .build();
         private Integer minOrderAmount = 10000;
-        private Store.OpenStatus status = Store.OpenStatus.OPEN;
+        private OpenStatus status = OpenStatus.OPEN;
 
         public Builder id(Long id) {
             this.id = id;
@@ -40,7 +41,7 @@ public class MockStore {
             return this;
         }
 
-        public Builder status(Store.OpenStatus status) {
+        public Builder status(OpenStatus status) {
             this.status = status;
             return this;
         }

--- a/common/src/main/java/com/food/common/menu/business/external/MenuService.java
+++ b/common/src/main/java/com/food/common/menu/business/external/MenuService.java
@@ -1,0 +1,16 @@
+package com.food.common.menu.business.external;
+
+import com.food.common.menu.business.external.dto.StoreMenus;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
+
+@Validated
+public interface MenuService {
+    /**
+     * 주어진 가게 ID의 가게데이터에 포함된 전체 메뉴목록을 조회한다.
+     * @param storeId 검색할 가게 ID. null일 수 없다.
+     * @return 검색한 가게의 메뉴데이터가 포함된 Dto. null일 수 없다.
+     */
+    StoreMenus findAllMenusByStoreId(@NotNull Long storeId);
+}

--- a/common/src/main/java/com/food/common/menu/business/external/dto/StoreMenus.java
+++ b/common/src/main/java/com/food/common/menu/business/external/dto/StoreMenus.java
@@ -1,0 +1,98 @@
+package com.food.common.menu.business.external.dto;
+
+import com.food.common.menu.business.internal.dto.MenuDto;
+import com.food.common.menu.business.internal.dto.MenuOptionDto;
+import com.food.common.menu.business.internal.dto.MenuSelectionDto;
+import com.food.common.utils.Amount;
+import lombok.Getter;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+public class StoreMenus {
+    private final Long storeId;
+    private final List<Menu> menus = new ArrayList<>();
+
+    public StoreMenus(Long storeId, List<MenuDto> menus, Map<Long, List<MenuOptionDto>> options, Map<Long, List<MenuSelectionDto>> selections) {
+        Assert.notNull(storeId, "storeId must not be null.");
+        Assert.notNull(menus, "menus must not be null.");
+        Assert.isTrue(!menus.isEmpty(), "menus must not be empty.");
+
+        this.storeId = storeId;
+        addAll(menus, options, selections);
+    }
+
+    private void addAll(List<MenuDto> menus, Map<Long, List<MenuOptionDto>> options, Map<Long, List<MenuSelectionDto>> selections) {
+        for (MenuDto menu : menus) {
+            this.menus.add(new Menu(menu, options.get(menu.getId()), selections));
+        }
+    }
+
+    @Getter
+    public static class Menu {
+        private Long menuId;
+        private String name;
+        private Amount amount;
+        private Integer cookingMinutes;
+        private final List<Option> options = new ArrayList<>();
+
+        public Menu(MenuDto menu, List<MenuOptionDto> options, Map<Long, List<MenuSelectionDto>> selections) {
+            this.menuId = menu.getId();
+            this.name = menu.getName();
+            this.amount = menu.getAmount();
+            this.cookingMinutes = menu.getCookingMinutes();
+
+            addAll(options, selections);
+        }
+
+        private void addAll(List<MenuOptionDto> options, Map<Long, List<MenuSelectionDto>> selections) {
+            for (MenuOptionDto option : options) {
+                this.options.add(new Option(option, selections.get(option.getId())));
+            }
+        }
+    }
+
+    @Getter
+    public static class Option {
+        private Long optionId;
+        private String name;
+        private Byte minSize;
+        private Byte maxSize;
+        private final List<Selection> selections = new ArrayList<>();
+
+        public Option(MenuOptionDto option, List<MenuSelectionDto> selections) {
+            this.optionId = option.getId();
+            this.name = option.getName();
+            this.minSize = option.getMinSize();
+            this.maxSize = option.getMaxSize();
+            addAll(selections);
+        }
+
+        private void addAll(List<MenuSelectionDto> selections) {
+            if (CollectionUtils.isEmpty(selections)) return;
+
+            List<Selection> addedSelections = selections.stream()
+                    .map(Selection::new)
+                    .collect(Collectors.toList());
+            this.selections.addAll(addedSelections);
+        }
+    }
+
+    @Getter
+    public static class Selection {
+        private Long id;
+        private String name;
+        private Amount amount;
+
+        public Selection(MenuSelectionDto selection) {
+            this.id = selection.getId();
+            this.name = selection.getName();
+            this.amount = getAmount();
+        }
+    }
+}

--- a/common/src/main/java/com/food/common/menu/business/internal/MenuCommonService.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/MenuCommonService.java
@@ -1,6 +1,7 @@
 package com.food.common.menu.business.internal;
 
 import com.food.common.menu.business.internal.dto.MenuDto;
+import com.food.common.menu.business.internal.dto.MenuDtos;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.NotEmpty;
@@ -15,4 +16,11 @@ public interface MenuCommonService {
      * @return 저장된 ID가 주입된 메뉴 목록. 순서는 요청목록 순서와 동일하며, null이거나 null인 요소를 포함하지 않는다.
      */
     List<MenuDto> saveAll(@NotEmpty List<@NotNull MenuDto> menus);
+
+    /**
+     * 주어진 가게ID로 메뉴 목록을 조회한다.
+     * @param storeId 가게데이터 ID
+     * @return 주어진 가게데이터 ID를 가진 결제로그 데이터 목록. null이거나 null인 요소는 포함하지 않는다.
+     */
+    MenuDtos findAllByStoreId(Long storeId);
 }

--- a/common/src/main/java/com/food/common/menu/business/internal/MenuCommonService.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/MenuCommonService.java
@@ -1,0 +1,18 @@
+package com.food.common.menu.business.internal;
+
+import com.food.common.menu.business.internal.dto.MenuDto;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Validated
+public interface MenuCommonService {
+    /**
+     * 주어진 메뉴데이터 객체들을 모두 저장한다.
+     * @param menus 저장할 메뉴데이터 목록. null인 요소를 포함할 수 없으며, 비어있을 수 없다.
+     * @return 저장된 ID가 주입된 메뉴 목록. 순서는 요청목록 순서와 동일하며, null이거나 null인 요소를 포함하지 않는다.
+     */
+    List<MenuDto> saveAll(@NotEmpty List<@NotNull MenuDto> menus);
+}

--- a/common/src/main/java/com/food/common/menu/business/internal/dto/MenuDtos.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/dto/MenuDtos.java
@@ -1,0 +1,32 @@
+package com.food.common.menu.business.internal.dto;
+
+import org.springframework.util.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MenuDtos {
+    private final List<MenuDto> menus = new ArrayList<>();
+
+    public MenuDtos(List<MenuDto> menus) {
+        Assert.notNull(menus);
+
+        this.menus.addAll(menus);
+    }
+
+    public boolean containsAll(List<Long> menuIds) {
+        if (menuIds == null) return false;
+
+        for (Long menuId : menuIds) {
+            if (!contains(menuId)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean contains(Long menuId) {
+        return menus.stream().anyMatch(menu -> menu.getId().equals(menuId));
+    }
+}

--- a/common/src/main/java/com/food/common/menu/business/internal/dto/MenuOptionDto.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/dto/MenuOptionDto.java
@@ -1,4 +1,4 @@
-package com.food.store;
+package com.food.common.menu.business.internal.dto;
 
 import com.food.common.menu.domain.MenuOption;
 import lombok.Getter;

--- a/common/src/main/java/com/food/common/menu/business/internal/dto/MenuSelectionDto.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/dto/MenuSelectionDto.java
@@ -1,4 +1,4 @@
-package com.food.store;
+package com.food.common.menu.business.internal.dto;
 
 import com.food.common.menu.domain.MenuSelection;
 import com.food.common.utils.Amount;

--- a/common/src/main/java/com/food/common/menu/domain/MenuOption.java
+++ b/common/src/main/java/com/food/common/menu/domain/MenuOption.java
@@ -1,5 +1,6 @@
 package com.food.common.menu.domain;
 
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 import org.hibernate.validator.constraints.Length;
@@ -13,6 +14,7 @@ import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+@Getter
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "tb_menu_option")
 @Entity
@@ -51,5 +53,9 @@ public class MenuOption {
         menuOption.maxSize = maxSize;
 
         return menuOption;
+    }
+
+    public Long getMenuId() {
+        return menu.getId();
     }
 }

--- a/common/src/main/java/com/food/common/menu/domain/MenuSelection.java
+++ b/common/src/main/java/com/food/common/menu/domain/MenuSelection.java
@@ -1,5 +1,6 @@
 package com.food.common.menu.domain;
 
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 import org.hibernate.validator.constraints.Length;
@@ -12,6 +13,7 @@ import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+@Getter
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "tb_menu_selection")
 @Entity
@@ -43,5 +45,9 @@ public class MenuSelection {
         menuSelection.amount = amount;
 
         return menuSelection;
+    }
+
+    public Long getOptionId() {
+        return option.getId();
     }
 }

--- a/common/src/main/java/com/food/common/store/business/internal/StoreCommonService.java
+++ b/common/src/main/java/com/food/common/store/business/internal/StoreCommonService.java
@@ -1,0 +1,15 @@
+package com.food.common.store.business.internal;
+
+import com.food.common.store.business.internal.dto.StoreDto;
+
+import javax.validation.constraints.NotNull;
+import java.util.Optional;
+
+public interface StoreCommonService {
+    /**
+     * ID로 가게데이터를 리턴한다.
+     * @param storeId 가게 ID. null일 수 없다.
+     * @return 주어진 ID를 보유한 가게데이터 또는 찾을 수 없는 경우 Optional#empty()
+     */
+    Optional<StoreDto> findById(@NotNull Long storeId);
+}

--- a/common/src/main/java/com/food/common/store/business/internal/StoreCommonService.java
+++ b/common/src/main/java/com/food/common/store/business/internal/StoreCommonService.java
@@ -12,4 +12,11 @@ public interface StoreCommonService {
      * @return 주어진 ID를 보유한 가게데이터 또는 찾을 수 없는 경우 Optional#empty()
      */
     Optional<StoreDto> findById(@NotNull Long storeId);
+
+    /**
+     * StoreId로 가게데이터의 존재유무를 리턴한다.
+     * @param storeId 검색할 ID. null일 수 없다.
+     * @return 데이터 존재 유무
+     */
+    boolean existsById(@NotNull Long storeId);
 }

--- a/common/src/main/java/com/food/common/store/business/internal/StoreOwnerEntityService.java
+++ b/common/src/main/java/com/food/common/store/business/internal/StoreOwnerEntityService.java
@@ -1,4 +1,4 @@
-package com.food.common.store.business;
+package com.food.common.store.business.internal;
 
 import com.food.common.store.domain.StoreOwner;
 import com.food.common.user.domain.User;

--- a/common/src/main/java/com/food/common/store/business/internal/dto/StoreDto.java
+++ b/common/src/main/java/com/food/common/store/business/internal/dto/StoreDto.java
@@ -1,0 +1,31 @@
+package com.food.common.store.business.internal.dto;
+
+import com.food.common.store.domain.Store;
+import com.food.common.store.domain.type.OpenStatus;
+import com.food.common.utils.Amount;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class StoreDto {
+    protected Long id;
+    protected String name;
+    protected Amount minOrderAmount;
+    protected OpenStatus status;
+
+    public StoreDto(@NotNull Store entity) {
+        this.id = entity.getId();
+        this.name = entity.getName();
+        this.minOrderAmount = Amount.won(entity.getMinOrderAmount());
+        this.status = entity.getStatus();
+    }
+
+    public boolean isClosed() {
+        return status == OpenStatus.CLOSED;
+    }
+}

--- a/common/src/main/java/com/food/common/store/business/internal/impl/DefaultStoreOwnerEntityService.java
+++ b/common/src/main/java/com/food/common/store/business/internal/impl/DefaultStoreOwnerEntityService.java
@@ -1,6 +1,6 @@
-package com.food.common.store.business.impl;
+package com.food.common.store.business.internal.impl;
 
-import com.food.common.store.business.StoreOwnerEntityService;
+import com.food.common.store.business.internal.StoreOwnerEntityService;
 import com.food.common.store.domain.StoreOwner;
 import com.food.common.user.domain.User;
 import com.food.common.user.repository.StoreOwnerRepository;

--- a/common/src/main/java/com/food/common/store/domain/Store.java
+++ b/common/src/main/java/com/food/common/store/domain/Store.java
@@ -1,5 +1,6 @@
 package com.food.common.store.domain;
 
+import com.food.common.store.domain.type.OpenStatus;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
@@ -57,16 +58,6 @@ public class Store {
         return store;
     }
 
-    public enum OpenStatus {
-        OPEN("운영 중"),
-        CLOSED("운영 종료")
-        ;
 
-        private final String description;
-
-        OpenStatus(String description) {
-            this.description = description;
-        }
-    }
 
 }

--- a/common/src/main/java/com/food/common/store/domain/type/OpenStatus.java
+++ b/common/src/main/java/com/food/common/store/domain/type/OpenStatus.java
@@ -1,0 +1,13 @@
+package com.food.common.store.domain.type;
+
+public enum OpenStatus {
+    OPEN("운영 중"),
+    CLOSED("운영 종료")
+    ;
+
+    private final String description;
+
+    OpenStatus(String description) {
+        this.description = description;
+    }
+}

--- a/common/src/main/java/com/food/common/user/business/internal/impl/DefaultUserCommonService.java
+++ b/common/src/main/java/com/food/common/user/business/internal/impl/DefaultUserCommonService.java
@@ -1,6 +1,6 @@
 package com.food.common.user.business.internal.impl;
 
-import com.food.common.store.business.StoreOwnerEntityService;
+import com.food.common.store.business.internal.StoreOwnerEntityService;
 import com.food.common.store.domain.StoreOwner;
 import com.food.common.user.business.internal.UserCommonService;
 import com.food.common.user.business.internal.dto.UserDto;

--- a/common/src/test/java/com/food/common/mock/store/MockStore.java
+++ b/common/src/test/java/com/food/common/mock/store/MockStore.java
@@ -3,6 +3,7 @@ package com.food.common.mock.store;
 import com.food.common.mock.user.MockUser;
 import com.food.common.store.domain.Store;
 import com.food.common.store.domain.StoreOwner;
+import com.food.common.store.domain.type.OpenStatus;
 
 public class MockStore {
     public static Builder builder()  {
@@ -18,7 +19,7 @@ public class MockStore {
                 .build())
                 .build();
         private Integer minOrderAmount = 10000;
-        private Store.OpenStatus status = Store.OpenStatus.OPEN;
+        private OpenStatus status = OpenStatus.OPEN;
 
         public Builder id(Long id) {
             this.id = id;
@@ -40,7 +41,7 @@ public class MockStore {
             return this;
         }
 
-        public Builder status(Store.OpenStatus status) {
+        public Builder status(OpenStatus status) {
             this.status = status;
             return this;
         }

--- a/common/src/test/java/com/food/common/unit/store/domain/StoreTests.java
+++ b/common/src/test/java/com/food/common/unit/store/domain/StoreTests.java
@@ -2,6 +2,7 @@ package com.food.common.unit.store.domain;
 
 import com.food.common.mock.store.MockStore;
 import com.food.common.store.domain.Store;
+import com.food.common.store.domain.type.OpenStatus;
 import com.food.common.unit.SuperValidationTests;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -86,7 +87,7 @@ public class StoreTests extends SuperValidationTests<Store> {
                 .status(null)
                 .build();
 
-        Set<Store> mockStoresWithEnumTypeStatus = Arrays.stream(Store.OpenStatus.values()).map(
+        Set<Store> mockStoresWithEnumTypeStatus = Arrays.stream(OpenStatus.values()).map(
                 status -> MockStore.builder()
                         .status(status)
                         .build()

--- a/order/src/main/java/com/food/order/error/OrderErrors.java
+++ b/order/src/main/java/com/food/order/error/OrderErrors.java
@@ -5,7 +5,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum OrderErrors implements ApplicationErrors {
-    NOT_FOUND_ORDER("ORDER_0001", "주문서를 찾을 수 없습니다.")
+    NOT_FOUND_ORDER("ORDER_0001", "주문서를 찾을 수 없습니다."),
+    NOT_FOUND_STORE_TO_ORDER("ORDER_0002", "주문할 가게를 찾을 수 없습니다."),
     ;
 
     private final String code;

--- a/order/src/main/java/com/food/order/error/OrderErrors.java
+++ b/order/src/main/java/com/food/order/error/OrderErrors.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 public enum OrderErrors implements ApplicationErrors {
     NOT_FOUND_ORDER("ORDER_0001", "주문서를 찾을 수 없습니다."),
     NOT_FOUND_STORE_TO_ORDER("ORDER_0002", "주문할 가게를 찾을 수 없습니다."),
-    ;
+    INVALID_STORE_OPEN_STATUS("ORDER_0003", "운영종료된 가게는 주문을 받을 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/order/src/main/java/com/food/order/error/OrderErrors.java
+++ b/order/src/main/java/com/food/order/error/OrderErrors.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 public enum OrderErrors implements ApplicationErrors {
     NOT_FOUND_ORDER("ORDER_0001", "주문서를 찾을 수 없습니다."),
     NOT_FOUND_STORE_TO_ORDER("ORDER_0002", "주문할 가게를 찾을 수 없습니다."),
-    INVALID_STORE_OPEN_STATUS("ORDER_0003", "운영종료된 가게는 주문을 받을 수 없습니다.");
+    INVALID_STORE_OPEN_STATUS("ORDER_0003", "운영종료된 가게는 주문을 받을 수 없습니다."),
+    NOT_FOUND_MENU_TO_ORDER("ORDER_0004", "주문할 메뉴를 찾을 수 없습니다."),
+    ;
 
     private final String code;
     private final String message;

--- a/order/src/test/java/com/food/order/common/stub/StubOrderService.java
+++ b/order/src/test/java/com/food/order/common/stub/StubOrderService.java
@@ -1,4 +1,4 @@
-package com.food.order.payment.stubrepository;
+package com.food.order.common.stub;
 
 import com.food.common.order.business.internal.OrderCommonService;
 import com.food.common.order.business.internal.dto.OrderDto;

--- a/order/src/test/java/com/food/order/order/DefaultOrderService.java
+++ b/order/src/test/java/com/food/order/order/DefaultOrderService.java
@@ -1,0 +1,34 @@
+package com.food.order.order;
+
+import com.food.common.menu.business.internal.MenuCommonService;
+import com.food.common.menu.business.internal.dto.MenuDtos;
+import com.food.common.order.business.internal.OrderCommonService;
+import com.food.common.store.business.internal.StoreCommonService;
+import com.food.common.store.business.internal.dto.StoreDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class DefaultOrderService implements OrderService {
+    private final OrderCommonService orderCommonService;
+    private final StoreCommonService storeCommonService;
+    private final MenuCommonService menuCommonService;
+
+    @Override
+    public Long order(OrderDoRequest request) {
+        StoreDto store = storeCommonService.findById(request.getStoreId())
+                .orElseThrow(() -> new NotFoundStoreException(request.getStoreId()));
+
+        if (store.isClosed()) {
+            throw new InvalidStoreOpenStatusException();
+        }
+
+        MenuDtos menus = menuCommonService.findAllByStoreId(request.getStoreId());
+        if (!menus.containsAll(request.getMenuIds())) {
+            throw new NotFoundMenuException();
+        }
+
+        return null;
+    }
+}

--- a/order/src/test/java/com/food/order/order/InvalidStoreOpenStatusException.java
+++ b/order/src/test/java/com/food/order/order/InvalidStoreOpenStatusException.java
@@ -1,0 +1,12 @@
+package com.food.order.order;
+
+import com.food.common.error.ApplicationErrors;
+import com.food.order.error.OrderErrors;
+
+public class InvalidStoreOpenStatusException extends RuntimeException {
+    private static final ApplicationErrors ERROR = OrderErrors.INVALID_STORE_OPEN_STATUS;
+
+    public InvalidStoreOpenStatusException() {
+        super(ERROR.getMessage());
+    }
+}

--- a/order/src/test/java/com/food/order/order/NotFoundMenuException.java
+++ b/order/src/test/java/com/food/order/order/NotFoundMenuException.java
@@ -1,0 +1,12 @@
+package com.food.order.order;
+
+import com.food.common.error.ApplicationErrors;
+import com.food.order.error.OrderErrors;
+
+public class NotFoundMenuException extends RuntimeException {
+    private static final ApplicationErrors ERROR = OrderErrors.NOT_FOUND_MENU_TO_ORDER;
+
+    public NotFoundMenuException() {
+        super(ERROR.getMessage());
+    }
+}

--- a/order/src/test/java/com/food/order/order/NotFoundStoreException.java
+++ b/order/src/test/java/com/food/order/order/NotFoundStoreException.java
@@ -1,0 +1,14 @@
+package com.food.order.order;
+
+import com.food.common.error.ApplicationErrors;
+import com.food.order.error.OrderErrors;
+
+public class NotFoundStoreException extends RuntimeException {
+    private static final ApplicationErrors ERROR = OrderErrors.NOT_FOUND_STORE_TO_ORDER;
+
+    public NotFoundStoreException(Long storeId) {
+        super(ERROR.appendMessage("storeId=" + storeId));
+    }
+
+
+}

--- a/order/src/test/java/com/food/order/order/OrderDoRequest.java
+++ b/order/src/test/java/com/food/order/order/OrderDoRequest.java
@@ -3,10 +3,28 @@ package com.food.order.order;
 import com.food.common.error.exception.InvalidRequestParameterException;
 import org.springframework.util.CollectionUtils;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class OrderDoRequest {
-    public OrderDoRequest(List<OrderMenuRequest> menus) {
+    private final Long storeId;
+    private final List<OrderMenuRequest> menus = new ArrayList<>();
+
+    public OrderDoRequest(Long storeId, List<OrderMenuRequest> menus) {
         if (CollectionUtils.isEmpty(menus)) throw new InvalidRequestParameterException("주문메뉴는 하나이상 존재해야 합니다.");
+
+        this.storeId = storeId;
+        this.menus.addAll(menus);
+    }
+
+    public Long getStoreId() {
+        return storeId;
+    }
+
+    public List<Long> getMenuIds() {
+        return menus.stream()
+                .map(OrderMenuRequest::getMenuId)
+                .collect(Collectors.toList());
     }
 }

--- a/order/src/test/java/com/food/order/order/OrderMenuRequest.java
+++ b/order/src/test/java/com/food/order/order/OrderMenuRequest.java
@@ -31,4 +31,8 @@ public class OrderMenuRequest {
             this.selections.addAll(addedSelections);
         }
     }
+
+    public Long getMenuId() {
+        return menuId;
+    }
 }

--- a/order/src/test/java/com/food/order/order/OrderService.java
+++ b/order/src/test/java/com/food/order/order/OrderService.java
@@ -1,0 +1,6 @@
+package com.food.order.order;
+
+public interface OrderService {
+
+    Long order(OrderDoRequest request);
+}

--- a/order/src/test/java/com/food/order/order/OrderTest.java
+++ b/order/src/test/java/com/food/order/order/OrderTest.java
@@ -17,23 +17,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class OrderTest {
-    /**
-     * 요구사항
-     *
-     * 요청 정보
-     * 가게 ID , 메뉴 목록 (NotEmpty)
-     * (메뉴 Unit: 메뉴 id, 수량, 선택지 목록) (NotNull)
-     * (메뉴 선택지 Unit: 메뉴 선택지 id, 수량) (NotNull)
-     *
-     * 주문메뉴는 하나이상 존재해야한다. (v)
-     * 주문메뉴의 수량은 1개 이상이어야한다. (v)
-     * 요청한 가게ID의 데이터가 존재해야한다. (v)
-     * 한 가게안의 메뉴만 주문이 가능하다. (v)
-     * 가게은 Open 상태여야한다. (v)
-     * 요청한 메뉴ID 목록의 데이터 전부 가게메뉴 내에 존재해야한다. (v)
-     * 가게의 최소 주문금액보다 주문금액이 같거나 커야한다.
-     * 상태가 '요청'인 주문데이터를 저장하고, 저장된 주문 ID를 반환한다.
-     */
     private OrderService orderService;
     private StubOrderService stubOrderCommonService;
     private StubStoreCommonService stubStoreCommonService;

--- a/order/src/test/java/com/food/order/order/StubMenuCommonService.java
+++ b/order/src/test/java/com/food/order/order/StubMenuCommonService.java
@@ -1,0 +1,55 @@
+package com.food.order.order;
+
+import com.food.common.menu.business.internal.MenuCommonService;
+import com.food.common.menu.business.internal.dto.MenuDto;
+import com.food.common.menu.business.internal.dto.MenuDtos;
+import com.food.order.order.mock.MockMenu;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class StubMenuCommonService implements MenuCommonService {
+    private final Map<Long, MenuDto> data = new HashMap<>();
+    private Long autoIncrementKey = -1L;
+
+    public MenuDto save(MenuDto menu) {
+        if (data.containsKey(menu.getId())) {
+            data.put(menu.getId(), menu);
+            return menu;
+        }
+
+        MockMenu newOne = MockMenu.testBuilder()
+                .id(autoIncrementKey--)
+                .storeId(menu.getStoreId())
+                .name(menu.getName())
+                .amount(menu.getAmount())
+                .cookingMinutes(menu.getCookingMinutes())
+                .build();
+        data.put(newOne.getId(), newOne);
+
+        return newOne;
+    }
+
+    @Override
+    public List<MenuDto> saveAll(List<MenuDto> menus) {
+        List<MenuDto> result = new ArrayList<>();
+
+        for (MenuDto menu : menus) {
+            result.add(save(menu));
+        }
+
+        return result;
+    }
+
+    @Override
+    public MenuDtos findAllByStoreId(Long storeId) {
+        List<MenuDto> menus = data.values().stream()
+                .filter(menu -> menu.getStoreId().equals(storeId))
+                .collect(Collectors.toList());
+
+        return new MenuDtos(menus);
+    }
+}

--- a/order/src/test/java/com/food/order/order/mock/MockStore.java
+++ b/order/src/test/java/com/food/order/order/mock/MockStore.java
@@ -1,0 +1,17 @@
+package com.food.order.order.mock;
+
+import com.food.common.store.business.internal.dto.StoreDto;
+import com.food.common.store.domain.type.OpenStatus;
+import com.food.common.utils.Amount;
+import lombok.Builder;
+
+public class MockStore extends StoreDto {
+
+    @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")
+    public MockStore(Long id, String name, Amount minOrderAmount, OpenStatus status) {
+        this.id = id;
+        this.name = name;
+        this.minOrderAmount = minOrderAmount;
+        this.status = status;
+    }
+}

--- a/order/src/test/java/com/food/order/order/stubrepository/StubStoreCommonService.java
+++ b/order/src/test/java/com/food/order/order/stubrepository/StubStoreCommonService.java
@@ -1,0 +1,36 @@
+package com.food.order.order.stubrepository;
+
+import com.food.common.store.business.internal.StoreCommonService;
+import com.food.common.store.business.internal.dto.StoreDto;
+import com.food.order.order.mock.MockStore;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class StubStoreCommonService implements StoreCommonService {
+    private final Map<Long, StoreDto> data = new HashMap<>();
+    private Long autoIncrementKey = -1L;
+
+    public StoreDto save(MockStore store) {
+        if (data.containsKey(store.getId())) {
+            data.put(store.getId(), store);
+            return store;
+        }
+
+        MockStore newOne = MockStore.testBuilder()
+                .id(autoIncrementKey--)
+                .name(store.getName())
+                .status(store.getStatus())
+                .minOrderAmount(store.getMinOrderAmount())
+                .build();
+        data.put(newOne.getId(), newOne);
+
+        return newOne;
+    }
+
+    @Override
+    public Optional<StoreDto> findById(Long storeId) {
+        return Optional.ofNullable(data.get(storeId));
+    }
+}

--- a/order/src/test/java/com/food/order/payment/PaymentAmountTest.java
+++ b/order/src/test/java/com/food/order/payment/PaymentAmountTest.java
@@ -11,7 +11,7 @@ import com.food.order.business.DefaultPaymentAmountService;
 import com.food.order.error.NotFoundPaymentException;
 import com.food.order.payment.mock.MockOrder;
 import com.food.order.payment.mock.MockPaymentLog;
-import com.food.order.payment.stubrepository.StubOrderService;
+import com.food.order.common.stub.StubOrderService;
 import com.food.order.payment.stubrepository.StubPaymentLogService;
 import com.food.order.payment.stubrepository.StubPaymentService;
 import org.junit.jupiter.api.Assertions;

--- a/order/src/test/java/com/food/order/payment/PaymentCancelTest.java
+++ b/order/src/test/java/com/food/order/payment/PaymentCancelTest.java
@@ -6,7 +6,7 @@ import com.food.order.payment.mock.MockOrder;
 import com.food.order.payment.mock.MockPayment;
 import com.food.order.payment.mock.MockPaymentLog;
 import com.food.order.payment.mock.MockRequestUser;
-import com.food.order.payment.stubrepository.StubOrderService;
+import com.food.order.common.stub.StubOrderService;
 import com.food.order.payment.stubrepository.StubPaymentLogService;
 import com.food.order.payment.stubrepository.StubPaymentService;
 import com.food.order.payment.stubrepository.StubPointService;

--- a/order/src/test/java/com/food/order/payment/PaymentDoTest.java
+++ b/order/src/test/java/com/food/order/payment/PaymentDoTest.java
@@ -11,7 +11,7 @@ import com.food.order.payment.mock.MockOrder;
 import com.food.order.payment.mock.MockPayment;
 import com.food.order.payment.mock.MockRequestUser;
 import com.food.common.payment.business.external.model.PaymentDoRequest;
-import com.food.order.payment.stubrepository.StubOrderService;
+import com.food.order.common.stub.StubOrderService;
 import com.food.order.payment.stubrepository.StubPaymentLogService;
 import com.food.order.payment.stubrepository.StubPaymentService;
 import com.food.order.payment.stubrepository.StubPointService;

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -21,6 +21,11 @@
             <artifactId>common</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/store/src/main/java/com/food/store/business/DefaultMenuService.java
+++ b/store/src/main/java/com/food/store/business/DefaultMenuService.java
@@ -1,0 +1,27 @@
+package com.food.store.business;
+
+import com.food.common.menu.business.external.MenuService;
+import com.food.common.menu.business.external.dto.StoreMenus;
+import com.food.common.menu.business.internal.MenuCommonService;
+import com.food.common.store.business.internal.StoreCommonService;
+import com.food.store.error.NotFoundStoreException;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DefaultMenuService implements MenuService {
+    private final StoreCommonService storeCommonService;
+    private final MenuCommonService menuCommonService;
+
+    @Override
+    public StoreMenus findAllMenusByStoreId(Long storeId) {
+        validateIfStoreExists(storeId);
+
+        return null;
+    }
+
+    private void validateIfStoreExists(Long storeId) {
+        if (!storeCommonService.existsById(storeId)) {
+            throw new NotFoundStoreException(storeId);
+        }
+    }
+}

--- a/store/src/main/java/com/food/store/error/MenuErrors.java
+++ b/store/src/main/java/com/food/store/error/MenuErrors.java
@@ -1,0 +1,23 @@
+package com.food.store.error;
+
+import com.food.common.error.ApplicationErrors;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum MenuErrors implements ApplicationErrors {
+    NOT_FOUND_STORE_TO_FIND_MENUS("MENU_0001", "메뉴 조회할 가게 정보를 찾을 수 없습니다."),
+    ;
+
+    private final String code;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/store/src/main/java/com/food/store/error/NotFoundStoreException.java
+++ b/store/src/main/java/com/food/store/error/NotFoundStoreException.java
@@ -1,0 +1,11 @@
+package com.food.store.error;
+
+import com.food.common.error.ApplicationErrors;
+
+public class NotFoundStoreException extends RuntimeException {
+    private static final ApplicationErrors ERROR = MenuErrors.NOT_FOUND_STORE_TO_FIND_MENUS;
+
+    public NotFoundStoreException(Long storeId) {
+        super(ERROR.appendMessage("storeId=" + storeId));
+    }
+}

--- a/store/src/test/java/com/food/store/MenuFindTest.java
+++ b/store/src/test/java/com/food/store/MenuFindTest.java
@@ -1,0 +1,85 @@
+package com.food.store;
+
+import com.food.common.menu.business.external.MenuService;
+import com.food.common.store.domain.type.OpenStatus;
+import com.food.common.utils.Amount;
+import com.food.store.business.DefaultMenuService;
+import com.food.store.error.NotFoundStoreException;
+import com.food.store.mock.MockStore;
+import com.food.store.stub.StubMenuCommonService;
+import com.food.store.stub.StubStoreCommonService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MenuFindTest {
+    private MenuService menuService;
+    private StubStoreCommonService storeCommonService;
+    private StubMenuCommonService menuCommonService;
+
+    @BeforeEach
+    void setup() {
+        storeCommonService = new StubStoreCommonService();
+        menuCommonService = new StubMenuCommonService();
+        menuService = new DefaultMenuService(storeCommonService, menuCommonService);
+
+    }
+
+    @Test
+    void 요청StoreId의_Store데이터가_존재해야한다() {
+        Long mockStoreId = givenStoreIdNotPresent();
+
+        NotFoundStoreException error = assertThrows(NotFoundStoreException.class, () -> menuService.findAllMenusByStoreId(mockStoreId));
+        assertTrue(error.getMessage().contains(String.valueOf(mockStoreId)));
+
+        assertDoesNotThrow(() -> menuService.findAllMenusByStoreId(givenStoreIdPresent()));
+    }
+
+    private Long givenStoreIdPresent() {
+        MockStore mockStore = MockStore.testBuilder()
+                .name("A Restaurant")
+                .status(OpenStatus.OPEN)
+                .minOrderAmount(Amount.won(12_000))
+                .build();
+        return storeCommonService.save(mockStore).getId();
+    }
+
+    private Long givenStoreIdNotPresent() {
+        Long storeId = 1L;
+
+        if (storeCommonService.existsById(storeId)) {
+            throw new IllegalArgumentException();
+        }
+
+        return storeId;
+    }
+
+//    @Test
+//    void 가게Id로_전체_메뉴목록을_조회한다() {
+//        MockMenu aMenu = MockMenu.testBuilder()
+//                .storeId(mockStoreId)
+//                .name("A Menu")
+//                .amount(Amount.won(15_000))
+//                .cookingMinutes(40)
+//                .build();
+//        Long mockAMenuId = menuCommonService.save(aMenu).getId();
+//
+//        MockMenu bMenu = MockMenu.testBuilder()
+//                .storeId(mockStoreId)
+//                .name("B Menu")
+//                .amount(Amount.won(7_000))
+//                .cookingMinutes(10)
+//                .build();
+//        Long mockBMenuId = menuCommonService.save(bMenu).getId();
+//
+//        //given
+//        Long storeId = 1L;
+//
+//        //when
+//        StoreMenus storeMenus = menuService.findAllMenusByStoreId(storeId);
+//
+//        //then
+//        assertEquals(storeId, storeMenus.getStoreId());
+//    }
+}

--- a/store/src/test/java/com/food/store/MenuOptionDto.java
+++ b/store/src/test/java/com/food/store/MenuOptionDto.java
@@ -1,0 +1,23 @@
+package com.food.store;
+
+import com.food.common.menu.domain.MenuOption;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class MenuOptionDto {
+    private Long id;
+    private Long menuId;
+    private String name;
+    private Byte minSize;
+    private Byte maxSize;
+
+    public MenuOptionDto(@NotNull MenuOption entity) {
+        this.id = entity.getId();
+        this.menuId = entity.getMenuId();
+        this.name = entity.getName();
+        this.minSize = entity.getMinSize();
+        this.maxSize = entity.getMaxSize();
+    }
+}

--- a/store/src/test/java/com/food/store/MenuSelectionDto.java
+++ b/store/src/test/java/com/food/store/MenuSelectionDto.java
@@ -1,0 +1,22 @@
+package com.food.store;
+
+import com.food.common.menu.domain.MenuSelection;
+import com.food.common.utils.Amount;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class MenuSelectionDto {
+    private Long id;
+    private Long optionId;
+    private String name;
+    private Amount amount;
+
+    public MenuSelectionDto(@NotNull MenuSelection entity) {
+        this.id = entity.getId();
+        this.optionId = entity.getOptionId();
+        this.name = entity.getSelection();
+        this.amount = Amount.won(entity.getAmount());
+    }
+}

--- a/store/src/test/java/com/food/store/mock/MockMenu.java
+++ b/store/src/test/java/com/food/store/mock/MockMenu.java
@@ -1,0 +1,17 @@
+package com.food.store.mock;
+
+import com.food.common.menu.business.internal.dto.MenuDto;
+import com.food.common.utils.Amount;
+import lombok.Builder;
+
+public class MockMenu extends MenuDto {
+
+    @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")
+    public MockMenu(Long id, Long storeId, String name, Amount amount, Integer cookingMinutes) {
+        this.id = id;
+        this.storeId = storeId;
+        this.name = name;
+        this.amount = amount;
+        this.cookingMinutes = cookingMinutes;
+    }
+}

--- a/store/src/test/java/com/food/store/mock/MockStore.java
+++ b/store/src/test/java/com/food/store/mock/MockStore.java
@@ -1,0 +1,17 @@
+package com.food.store.mock;
+
+import com.food.common.store.business.internal.dto.StoreDto;
+import com.food.common.store.domain.type.OpenStatus;
+import com.food.common.utils.Amount;
+import lombok.Builder;
+
+public class MockStore extends StoreDto {
+
+    @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")
+    public MockStore(Long id, String name, Amount minOrderAmount, OpenStatus status) {
+        this.id = id;
+        this.name = name;
+        this.minOrderAmount = minOrderAmount;
+        this.status = status;
+    }
+}

--- a/store/src/test/java/com/food/store/stub/StubMenuCommonService.java
+++ b/store/src/test/java/com/food/store/stub/StubMenuCommonService.java
@@ -1,0 +1,55 @@
+package com.food.store.stub;
+
+import com.food.common.menu.business.internal.MenuCommonService;
+import com.food.common.menu.business.internal.dto.MenuDto;
+import com.food.common.menu.business.internal.dto.MenuDtos;
+import com.food.store.mock.MockMenu;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class StubMenuCommonService implements MenuCommonService {
+    private final Map<Long, MenuDto> data = new HashMap<>();
+    private Long autoIncrementKey = -1L;
+
+    public MenuDto save(MenuDto menu) {
+        if (data.containsKey(menu.getId())) {
+            data.put(menu.getId(), menu);
+            return menu;
+        }
+
+        MockMenu newOne = MockMenu.testBuilder()
+                .id(autoIncrementKey--)
+                .storeId(menu.getStoreId())
+                .name(menu.getName())
+                .amount(menu.getAmount())
+                .cookingMinutes(menu.getCookingMinutes())
+                .build();
+        data.put(newOne.getId(), newOne);
+
+        return newOne;
+    }
+
+    @Override
+    public List<MenuDto> saveAll(List<MenuDto> menus) {
+        List<MenuDto> result = new ArrayList<>();
+
+        for (MenuDto menu : menus) {
+            result.add(save(menu));
+        }
+
+        return result;
+    }
+
+    @Override
+    public MenuDtos findAllByStoreId(Long storeId) {
+        List<MenuDto> menus = data.values().stream()
+                .filter(menu -> menu.getStoreId().equals(storeId))
+                .collect(Collectors.toList());
+
+        return new MenuDtos(menus);
+    }
+}

--- a/store/src/test/java/com/food/store/stub/StubStoreCommonService.java
+++ b/store/src/test/java/com/food/store/stub/StubStoreCommonService.java
@@ -1,8 +1,8 @@
-package com.food.order.order.stubrepository;
+package com.food.store.stub;
 
 import com.food.common.store.business.internal.StoreCommonService;
 import com.food.common.store.business.internal.dto.StoreDto;
-import com.food.order.order.mock.MockStore;
+import com.food.store.mock.MockStore;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,6 +36,6 @@ public class StubStoreCommonService implements StoreCommonService {
 
     @Override
     public boolean existsById(Long storeId) {
-        return false;
+        return data.containsKey(storeId);
     }
 }


### PR DESCRIPTION
#### 특정 가게의 전체메뉴 조회 요구사항
- [x] **StoreId로 구성된 가게 데이터가 존재해야한다.**
- [ ] 메뉴 전체목록을 조회한다.
- [ ] Store의 메뉴는 1개 이상 존재해야한다.,
- [ ] 메뉴안에 옵션이 존재할 경우 옵션목록도 함께 가져온다.

#### 주문하기 요구사항
- [x] 주문메뉴는 하나이상 존재해야한다.
- [x] 주문메뉴의 수량은 1개 이상이어야한다
- [x] **요청한 가게ID의 데이터가 존재해야한다.**
- [x] **한 가게 안의 메뉴만 주문이 가능하다.**
- [x] **가게는 Open 상태여야 한다.**
- [x] **요청한 메뉴 ID 목록의 데이터 전부 가게 메뉴 내에 존재해야한다.**
- [ ] 가게의 최소 주문금액보다 주문금액이 같거나 커야한다.
- [ ] 상태가 ‘요청’인 주문데이터를 저장하고, 저장된 주문 ID를 반환한다.

---
#### 변경 사항
* Store Module의 spring-boot-starter-test 의존성 추가
* 엔티티 Store의 내부 클래스 분리 
* Store Module에서 사용할 MenuService생성
* MenuOptionDto, MenuSelectionDto 클래스 생성