### PR TITLE
가게의 전체메뉴 조회 기능 구현

### DIFF
--- a/app/src/test/resources/schema.sql
+++ b/app/src/test/resources/schema.sql
@@ -73,7 +73,24 @@ create table tb_menu
     store_id bigint not null,
     name varchar(50) not null,
     amount mediumint not null default 0,
-    cooking_time mediumint not null
+    cooking_minutes mediumint not null
+);
+
+create table tb_menu_option
+(
+    menu_option_id bigint auto_increment primary key,
+    menu_id bigint not null,
+    name varchar(30) not null,
+    min_size tinyint not null,
+    max_size tinyint not null
+);
+
+create table tb_menu_selection
+(
+    menu_selection_id bigint auto_increment primary key,
+    menu_option_id bigint not null,
+    name varchar(50) not null,
+    amount mediumint not null
 );
 
 create table tb_food_category

--- a/common/src/main/java/com/food/common/menu/business/external/dto/StoreMenus.java
+++ b/common/src/main/java/com/food/common/menu/business/external/dto/StoreMenus.java
@@ -47,7 +47,9 @@ public class StoreMenus {
             this.amount = menu.getAmount();
             this.cookingMinutes = menu.getCookingMinutes();
 
-            addAll(options, selections);
+            if (!CollectionUtils.isEmpty(options)) {
+                addAll(options, selections);
+            }
         }
 
         private void addAll(List<MenuOptionDto> options, Map<Long, List<MenuSelectionDto>> selections) {
@@ -70,7 +72,10 @@ public class StoreMenus {
             this.name = option.getName();
             this.minSize = option.getMinSize();
             this.maxSize = option.getMaxSize();
-            addAll(selections);
+
+            if (!CollectionUtils.isEmpty(selections)) {
+                addAll(selections);
+            }
         }
 
         private void addAll(List<MenuSelectionDto> selections) {
@@ -92,7 +97,7 @@ public class StoreMenus {
         public Selection(MenuSelectionDto selection) {
             this.id = selection.getId();
             this.name = selection.getName();
-            this.amount = getAmount();
+            this.amount = selection.getAmount();
         }
     }
 }

--- a/common/src/main/java/com/food/common/menu/business/internal/MenuOptionCommonService.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/MenuOptionCommonService.java
@@ -1,0 +1,24 @@
+package com.food.common.menu.business.internal;
+
+import com.food.common.menu.business.internal.dto.MenuOptionDto;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Validated
+public interface MenuOptionCommonService {
+
+    /**
+     * 주어진 메뉴ID 목록의 연관된 옵션을 조회한다.
+     * @param menuIds 메뉴데이터 ID 목록
+     * @return 주어진 메뉴 ID를 가진 메뉴옵션의 데이터 목록.
+     *         {Key: MenuId, Value: MenuOption 목록}
+     *         null이거나 null인 요소는 포함하지 않는다.
+     *         Menu에 해당하는 메뉴옵션이 존재하지 않을 경우 Map에 요소를 포함시키지 않는다.
+     */
+    Map<Long, List<MenuOptionDto>> findAllByMenuIds(@NotEmpty Set<@NotNull Long> menuIds);
+}

--- a/common/src/main/java/com/food/common/menu/business/internal/MenuSelectionCommonService.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/MenuSelectionCommonService.java
@@ -1,0 +1,22 @@
+package com.food.common.menu.business.internal;
+
+import com.food.common.menu.business.internal.dto.MenuSelectionDto;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public interface MenuSelectionCommonService {
+
+    /**
+     * 주어진 메뉴옵션ID 목록의 연관된 선택지을 조회한다.
+     * @param menuOptionIds 메뉴 옵션데이터 ID 목록.
+     * @return 주어진 메뉴 ID를 가진 메뉴선택지의 데이터 목록.
+     *         {Key: MenuOptionId, Value: MenuSelection 목록}
+     *         null이거나 null인 요소는 포함하지 않는다.
+     * @throws NotExistMenuSelectionException MenuOption에 해당하는 메뉴선택지가 1개 이상 존재하지 않을 경우 발생한다.
+     */
+    Map<Long, List<MenuSelectionDto>> findAllByMenuOptionIds(@NotEmpty Set<@NotNull Long> menuOptionIds);
+}

--- a/common/src/main/java/com/food/common/menu/business/internal/dto/MenuDtos.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/dto/MenuDtos.java
@@ -3,7 +3,10 @@ package com.food.common.menu.business.internal.dto;
 import org.springframework.util.Assert;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class MenuDtos {
     private final List<MenuDto> menus = new ArrayList<>();
@@ -28,5 +31,19 @@ public class MenuDtos {
 
     private boolean contains(Long menuId) {
         return menus.stream().anyMatch(menu -> menu.getId().equals(menuId));
+    }
+
+    public boolean isEmpty() {
+        return menus.isEmpty();
+    }
+
+    public Set<Long> mapToMenuIds() {
+        return menus.stream()
+                .map(MenuDto::getId)
+                .collect(Collectors.toSet());
+    }
+
+    public List<MenuDto> get() {
+        return Collections.unmodifiableList(menus);
     }
 }

--- a/common/src/main/java/com/food/common/menu/business/internal/dto/MenuOptionDto.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/dto/MenuOptionDto.java
@@ -2,16 +2,20 @@ package com.food.common.menu.business.internal.dto;
 
 import com.food.common.menu.domain.MenuOption;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
 @Getter
 public class MenuOptionDto {
-    private Long id;
-    private Long menuId;
-    private String name;
-    private Byte minSize;
-    private Byte maxSize;
+    protected Long id;
+    protected Long menuId;
+    protected String name;
+    protected Byte minSize;
+    protected Byte maxSize;
 
     public MenuOptionDto(@NotNull MenuOption entity) {
         this.id = entity.getId();

--- a/common/src/main/java/com/food/common/menu/business/internal/dto/MenuSelectionDto.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/dto/MenuSelectionDto.java
@@ -3,15 +3,19 @@ package com.food.common.menu.business.internal.dto;
 import com.food.common.menu.domain.MenuSelection;
 import com.food.common.utils.Amount;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
 @Getter
 public class MenuSelectionDto {
-    private Long id;
-    private Long optionId;
-    private String name;
-    private Amount amount;
+    protected Long id;
+    protected Long optionId;
+    protected String name;
+    protected Amount amount;
 
     public MenuSelectionDto(@NotNull MenuSelection entity) {
         this.id = entity.getId();

--- a/common/src/main/java/com/food/common/menu/business/internal/dto/MenuSelectionDto.java
+++ b/common/src/main/java/com/food/common/menu/business/internal/dto/MenuSelectionDto.java
@@ -16,7 +16,7 @@ public class MenuSelectionDto {
     public MenuSelectionDto(@NotNull MenuSelection entity) {
         this.id = entity.getId();
         this.optionId = entity.getOptionId();
-        this.name = entity.getSelection();
+        this.name = entity.getName();
         this.amount = Amount.won(entity.getAmount());
     }
 }

--- a/common/src/main/java/com/food/common/menu/domain/Menu.java
+++ b/common/src/main/java/com/food/common/menu/domain/Menu.java
@@ -3,6 +3,7 @@ package com.food.common.menu.domain;
 import com.food.common.store.domain.Store;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Comment;
 import org.hibernate.validator.constraints.Length;
 
@@ -10,6 +11,9 @@ import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PositiveOrZero;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
@@ -45,6 +49,10 @@ public class Menu {
     @NotNull
     private Integer cookingMinutes;
 
+    @BatchSize(size = 30)
+    @OneToMany(mappedBy = "menu")
+    private final List<MenuOption> options = new ArrayList<>();
+
     public static Menu create(Store store, String name, Integer amount, Integer cookingMinutes) {
         Menu menu = new Menu();
         menu.store = store;
@@ -57,5 +65,11 @@ public class Menu {
 
     public Long getStoreId() {
         return store.getId();
+    }
+
+    public List<MenuOption> getOptions() {
+        if (options == null) return Collections.emptyList();
+
+        return Collections.unmodifiableList(options);
     }
 }

--- a/common/src/main/java/com/food/common/menu/domain/MenuOption.java
+++ b/common/src/main/java/com/food/common/menu/domain/MenuOption.java
@@ -2,13 +2,17 @@ package com.food.common.menu.domain;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Comment;
 import org.hibernate.validator.constraints.Length;
 
 import javax.persistence.*;
+import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
@@ -36,14 +40,18 @@ public class MenuOption {
     private String name;
 
     @Comment("최소 선택 개수")
-    @Size(max = 100)
+    @Max(100)
     @NotNull
     private Byte minSize;
 
     @Comment("최대 선택 개수")
-    @Size(max = 100)
+    @Max(100)
     @NotNull
     private Byte maxSize;
+
+    @BatchSize(size = 30)
+    @OneToMany(mappedBy = "option")
+    private final List<MenuSelection> selections = new ArrayList<>();
 
     public static MenuOption menuOption(Menu menu, String name, Byte minSize, Byte maxSize) {
         MenuOption menuOption = new MenuOption();

--- a/common/src/main/java/com/food/common/menu/domain/MenuSelection.java
+++ b/common/src/main/java/com/food/common/menu/domain/MenuSelection.java
@@ -31,7 +31,7 @@ public class MenuSelection {
     @Comment("선택지")
     @Length(max = 50)
     @NotNull
-    private String selection;
+    private String name;
 
     @Comment("금액")
     @PositiveOrZero
@@ -41,7 +41,7 @@ public class MenuSelection {
     public static MenuSelection create(MenuOption option, String selection, Integer amount) {
         MenuSelection menuSelection = new MenuSelection();
         menuSelection.option = option;
-        menuSelection.selection = selection;
+        menuSelection.name = selection;
         menuSelection.amount = amount;
 
         return menuSelection;

--- a/common/src/main/java/com/food/common/menu/repository/MenuRepository.java
+++ b/common/src/main/java/com/food/common/menu/repository/MenuRepository.java
@@ -1,7 +1,11 @@
 package com.food.common.menu.repository;
 
 import com.food.common.menu.domain.Menu;
+import com.food.common.store.domain.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MenuRepository extends JpaRepository<Menu, Long> {
+    List<Menu> findAllByStore(Store store);
 }

--- a/common/src/main/java/com/food/common/utils/ByteUtils.java
+++ b/common/src/main/java/com/food/common/utils/ByteUtils.java
@@ -1,0 +1,8 @@
+package com.food.common.utils;
+
+public abstract class ByteUtils {
+
+    public static Byte byteValue(int i) {
+        return Integer.valueOf(i).byteValue();
+    }
+}

--- a/common/src/test/java/com/food/common/ApplicationTests.java
+++ b/common/src/test/java/com/food/common/ApplicationTests.java
@@ -1,0 +1,9 @@
+package com.food.common;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ApplicationTests {
+
+    public void contextLoads() {}
+}

--- a/common/src/test/java/com/food/common/repository/MenuRepositoryTest.java
+++ b/common/src/test/java/com/food/common/repository/MenuRepositoryTest.java
@@ -1,0 +1,81 @@
+package com.food.common.repository;
+
+import com.food.common.menu.domain.Menu;
+import com.food.common.menu.domain.MenuOption;
+import com.food.common.menu.domain.MenuSelection;
+import com.food.common.menu.repository.MenuOptionRepository;
+import com.food.common.menu.repository.MenuRepository;
+import com.food.common.menu.repository.MenuSelectionRepository;
+import com.food.common.store.domain.Store;
+import com.food.common.store.domain.StoreOwner;
+import com.food.common.store.domain.type.OpenStatus;
+import com.food.common.store.repository.StoreRepository;
+import com.food.common.user.domain.User;
+import com.food.common.user.repository.StoreOwnerRepository;
+import com.food.common.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.food.common.utils.ByteUtils.byteValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+public class MenuRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StoreOwnerRepository storeOwnerRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private MenuRepository menuRepository;
+
+    @Autowired
+    private MenuOptionRepository menuOptionRepository;
+
+    @Autowired
+    private MenuSelectionRepository menuSelectionRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    void Batch사이즈없이_일대다조회시_쿼리가_몇개실행되는지_테스트한다() {
+        //given
+        User mockUser = userRepository.save(User.create("testNick"));
+        StoreOwner mockStoreOwner = storeOwnerRepository.save(StoreOwner.create(mockUser));
+        Store mockStore = storeRepository.save(Store.create("A Restaurant", mockStoreOwner, 12_000, OpenStatus.OPEN));
+
+        Menu mockMenuA = menuRepository.save(Menu.create(mockStore, "A Menu", 14_000, 30));
+        Menu mockMenuB = menuRepository.save(Menu.create(mockStore, "B Menu", 7_000, 20));
+        Menu mockMenuC = menuRepository.save(Menu.create(mockStore, "A Menu", 3_000, 10));
+
+        MenuOption mockOptionA = menuOptionRepository.save(MenuOption.menuOption(mockMenuA, "A Option - A Menu", byteValue(1), byteValue(1)));
+        MenuOption mockOptionB = menuOptionRepository.save(MenuOption.menuOption(mockMenuB, "B Option - B Menu", byteValue(0), byteValue(2)));
+
+        MenuSelection mockMenuSelectionA = menuSelectionRepository.save(MenuSelection.create(mockOptionA, "A Selection - A Option - A Menu", 3_000));
+        MenuSelection mockMenuSelectionB = menuSelectionRepository.save(MenuSelection.create(mockOptionA, "B Selection - A Option - A Menu", 2_000));
+        MenuSelection mockMenuSelectionC = menuSelectionRepository.save(MenuSelection.create(mockOptionA, "C Selection - A Option - A Menu", 1_000));
+        MenuSelection mockMenuSelectionD = menuSelectionRepository.save(MenuSelection.create(mockOptionB, "D Selection - B Option - B Menu", 1_000));
+        MenuSelection mockMenuSelectionE = menuSelectionRepository.save(MenuSelection.create(mockOptionB, "E Selection - B Option - B Menu", 1_000));
+
+        em.flush();
+        em.clear();
+
+        //when
+        List<Menu> menus = menuRepository.findAllByStore(mockStore);
+
+        //then
+        assertEquals(3, menus.size());
+        assertEquals(1, menus.get(0).getOptions().size());
+        assertEquals(3, menus.get(0).getOptions().get(0).getSelections().size());
+    }
+}

--- a/store/src/main/java/com/food/store/business/DefaultMenuService.java
+++ b/store/src/main/java/com/food/store/business/DefaultMenuService.java
@@ -3,20 +3,39 @@ package com.food.store.business;
 import com.food.common.menu.business.external.MenuService;
 import com.food.common.menu.business.external.dto.StoreMenus;
 import com.food.common.menu.business.internal.MenuCommonService;
+import com.food.common.menu.business.internal.MenuOptionCommonService;
+import com.food.common.menu.business.internal.MenuSelectionCommonService;
+import com.food.common.menu.business.internal.dto.MenuDtos;
+import com.food.common.menu.business.internal.dto.MenuOptionDto;
+import com.food.common.menu.business.internal.dto.MenuSelectionDto;
 import com.food.common.store.business.internal.StoreCommonService;
+import com.food.store.error.NotExistMenusException;
 import com.food.store.error.NotFoundStoreException;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 public class DefaultMenuService implements MenuService {
     private final StoreCommonService storeCommonService;
     private final MenuCommonService menuCommonService;
+    private final MenuOptionCommonService menuOptionCommonService;
+    private final MenuSelectionCommonService menuSelectionCommonService;
 
     @Override
     public StoreMenus findAllMenusByStoreId(Long storeId) {
         validateIfStoreExists(storeId);
 
-        return null;
+        MenuDtos menus = menuCommonService.findAllByStoreId(storeId);
+        if (menus.isEmpty()) {
+            throw new NotExistMenusException();
+        }
+
+        Map<Long, List<MenuOptionDto>> menuOptions = menuOptionCommonService.findAllByMenuIds(menus.mapToMenuIds());
+        Map<Long, List<MenuSelectionDto>> menuSelections = menuSelectionCommonService.findAllByMenuOptionIds(menuOptions.keySet());
+
+        return new StoreMenus(storeId, menus.get(), menuOptions, menuSelections);
     }
 
     private void validateIfStoreExists(Long storeId) {

--- a/store/src/main/java/com/food/store/error/MenuErrors.java
+++ b/store/src/main/java/com/food/store/error/MenuErrors.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MenuErrors implements ApplicationErrors {
     NOT_FOUND_STORE_TO_FIND_MENUS("MENU_0001", "메뉴 조회할 가게 정보를 찾을 수 없습니다."),
+    NOT_EXIST_MENUS("MENU_0002", "메뉴가 존재하지 않습니다. 가게의 메뉴는 한가지 이상 존재해야 합니다."),
     ;
 
     private final String code;

--- a/store/src/main/java/com/food/store/error/NotExistMenusException.java
+++ b/store/src/main/java/com/food/store/error/NotExistMenusException.java
@@ -1,0 +1,11 @@
+package com.food.store.error;
+
+import com.food.common.error.ApplicationErrors;
+
+public class NotExistMenusException extends RuntimeException {
+    private static final ApplicationErrors ERROR = MenuErrors.NOT_EXIST_MENUS;
+
+    public NotExistMenusException() {
+        super(ERROR.getMessage());
+    }
+}

--- a/store/src/test/java/com/food/store/MenuFindTest.java
+++ b/store/src/test/java/com/food/store/MenuFindTest.java
@@ -1,15 +1,28 @@
 package com.food.store;
 
 import com.food.common.menu.business.external.MenuService;
+import com.food.common.menu.business.external.dto.StoreMenus;
+import com.food.common.menu.business.internal.dto.MenuDto;
+import com.food.common.menu.business.internal.dto.MenuOptionDto;
+import com.food.common.menu.business.internal.dto.MenuSelectionDto;
 import com.food.common.store.domain.type.OpenStatus;
 import com.food.common.utils.Amount;
+import com.food.common.utils.ByteUtils;
 import com.food.store.business.DefaultMenuService;
+import com.food.store.error.NotExistMenusException;
 import com.food.store.error.NotFoundStoreException;
+import com.food.store.mock.MockMenu;
+import com.food.store.mock.MockMenuOption;
+import com.food.store.mock.MockMenuSelection;
 import com.food.store.mock.MockStore;
 import com.food.store.stub.StubMenuCommonService;
+import com.food.store.stub.StubMenuOptionCommonService;
+import com.food.store.stub.StubMenuSelectionCommonService;
 import com.food.store.stub.StubStoreCommonService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -17,13 +30,16 @@ public class MenuFindTest {
     private MenuService menuService;
     private StubStoreCommonService storeCommonService;
     private StubMenuCommonService menuCommonService;
+    private StubMenuOptionCommonService menuOptionCommonService;
+    private StubMenuSelectionCommonService menuSelectionCommonService;
 
     @BeforeEach
     void setup() {
         storeCommonService = new StubStoreCommonService();
         menuCommonService = new StubMenuCommonService();
-        menuService = new DefaultMenuService(storeCommonService, menuCommonService);
-
+        menuOptionCommonService = new StubMenuOptionCommonService();
+        menuSelectionCommonService = new StubMenuSelectionCommonService();
+        menuService = new DefaultMenuService(storeCommonService, menuCommonService, menuOptionCommonService, menuSelectionCommonService);
     }
 
     @Test
@@ -32,9 +48,63 @@ public class MenuFindTest {
 
         NotFoundStoreException error = assertThrows(NotFoundStoreException.class, () -> menuService.findAllMenusByStoreId(mockStoreId));
         assertTrue(error.getMessage().contains(String.valueOf(mockStoreId)));
-
-        assertDoesNotThrow(() -> menuService.findAllMenusByStoreId(givenStoreIdPresent()));
     }
+
+    @Test
+    void 가게메뉴는_한가지_이상_존재해야한다() {
+        Long mockStoreId = givenStoreIdPresent();
+
+        assertThrows(NotExistMenusException.class, () -> menuService.findAllMenusByStoreId(mockStoreId));
+    }
+
+    @Test
+    void 메뉴_안에_옵션이_존재할_경우_옵션목록도_함께_가져온다() {
+        //given
+        Long mockStoreId = givenStoreIdPresent();
+
+        assertThrows(NotExistMenusException.class, () -> menuService.findAllMenusByStoreId(mockStoreId));
+
+        MenuDto mockMenuA = givenMenuPresent(mockStoreId, "A Menu", 15_000, 40);
+        MenuDto mockMenuB = givenMenuPresent(mockStoreId, "B Menu", 7_000, 10);
+
+        MenuOptionDto mockMenuOptionA = givenMenuOptionPresent(mockMenuA.getId(), "A MenuOption", 1, 1);
+
+        MenuSelectionDto mockMenuSelectionA = givenMenuSelectionPresent(mockMenuOptionA.getId(), "A Selection", 3_000);
+        MenuSelectionDto mockMenuSelectionB = givenMenuSelectionPresent(mockMenuOptionA.getId(), "B Selection", 1_000);
+
+        //when
+        StoreMenus result = menuService.findAllMenusByStoreId(mockStoreId);
+
+        //then
+        assertEquals(2, result.getMenus().size());
+        List<StoreMenus.Menu> menus = result.getMenus();
+
+        StoreMenus.Menu findAMenu = menus.stream()
+                .filter(menu -> menu.getMenuId().equals(mockMenuA.getId())).findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+        assertEquals(mockMenuA.getName(), findAMenu.getName());
+        assertEquals(mockMenuA.getAmount(), findAMenu.getAmount());
+        assertEquals(mockMenuA.getCookingMinutes(), findAMenu.getCookingMinutes());
+
+        assertEquals(1, findAMenu.getOptions().size());
+
+        StoreMenus.Option findAOption = findAMenu.getOptions().get(0);
+        assertEquals(mockMenuOptionA.getId(), findAOption.getOptionId());
+        assertEquals(mockMenuOptionA.getName(), findAOption.getName());
+        assertEquals(mockMenuOptionA.getMinSize(), findAOption.getMinSize());
+        assertEquals(mockMenuOptionA.getMaxSize(), findAOption.getMaxSize());
+
+        List<StoreMenus.Selection> findSelections = findAOption.getSelections();
+        assertEquals(2, findSelections.size());
+        StoreMenus.Selection findAMenuSelection = findSelections.stream()
+                .filter(selection -> selection.getId().equals(mockMenuSelectionA.getId())).findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+
+        assertEquals(mockMenuSelectionA.getId(), findAMenuSelection.getId());
+        assertEquals(mockMenuSelectionA.getName(), findAMenuSelection.getName());
+        assertEquals(mockMenuSelectionA.getAmount(), findAMenuSelection.getAmount());
+    }
+
 
     private Long givenStoreIdPresent() {
         MockStore mockStore = MockStore.testBuilder()
@@ -55,31 +125,33 @@ public class MenuFindTest {
         return storeId;
     }
 
-//    @Test
-//    void 가게Id로_전체_메뉴목록을_조회한다() {
-//        MockMenu aMenu = MockMenu.testBuilder()
-//                .storeId(mockStoreId)
-//                .name("A Menu")
-//                .amount(Amount.won(15_000))
-//                .cookingMinutes(40)
-//                .build();
-//        Long mockAMenuId = menuCommonService.save(aMenu).getId();
-//
-//        MockMenu bMenu = MockMenu.testBuilder()
-//                .storeId(mockStoreId)
-//                .name("B Menu")
-//                .amount(Amount.won(7_000))
-//                .cookingMinutes(10)
-//                .build();
-//        Long mockBMenuId = menuCommonService.save(bMenu).getId();
-//
-//        //given
-//        Long storeId = 1L;
-//
-//        //when
-//        StoreMenus storeMenus = menuService.findAllMenusByStoreId(storeId);
-//
-//        //then
-//        assertEquals(storeId, storeMenus.getStoreId());
-//    }
+    private MenuDto givenMenuPresent(Long storeId, String name, Integer amount, Integer cookingMinutes) {
+        MockMenu mockMenu = MockMenu.testBuilder()
+                .storeId(storeId)
+                .name(name)
+                .amount(Amount.won(amount))
+                .cookingMinutes(cookingMinutes)
+                .build();
+        return menuCommonService.save(mockMenu);
+    }
+
+    private MenuOptionDto givenMenuOptionPresent(Long menuId, String name, Integer minSize, Integer maxSize) {
+        MockMenuOption mockMenuOption = MockMenuOption.testBuilder()
+                .menuId(menuId)
+                .name(name)
+                .minSize(ByteUtils.byteValue(minSize))
+                .maxSize(ByteUtils.byteValue(maxSize))
+                .build();
+        return menuOptionCommonService.save(mockMenuOption);
+    }
+
+    private MenuSelectionDto givenMenuSelectionPresent(Long optionId, String name, Integer amount) {
+        MockMenuSelection mockMenuSelection = MockMenuSelection.testBuilder()
+                .optionId(optionId)
+                .name(name)
+                .amount(Amount.won(amount))
+                .build();
+
+        return menuSelectionCommonService.save(mockMenuSelection);
+    }
 }

--- a/store/src/test/java/com/food/store/mock/MockMenuOption.java
+++ b/store/src/test/java/com/food/store/mock/MockMenuOption.java
@@ -1,0 +1,16 @@
+package com.food.store.mock;
+
+import com.food.common.menu.business.internal.dto.MenuOptionDto;
+import lombok.Builder;
+
+public class MockMenuOption extends MenuOptionDto {
+
+    @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")
+    public MockMenuOption(Long id, Long menuId, String name, Byte minSize, Byte maxSize) {
+        this.id = id;
+        this.menuId = menuId;
+        this.name = name;
+        this.minSize = minSize;
+        this.maxSize = maxSize;
+    }
+}

--- a/store/src/test/java/com/food/store/mock/MockMenuSelection.java
+++ b/store/src/test/java/com/food/store/mock/MockMenuSelection.java
@@ -1,0 +1,16 @@
+package com.food.store.mock;
+
+import com.food.common.menu.business.internal.dto.MenuSelectionDto;
+import com.food.common.utils.Amount;
+import lombok.Builder;
+
+public class MockMenuSelection extends MenuSelectionDto {
+
+    @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")
+    public MockMenuSelection(Long id, Long optionId, String name, Amount amount) {
+        this.id = id;
+        this.optionId = optionId;
+        this.name = name;
+        this.amount = amount;
+    }
+}

--- a/store/src/test/java/com/food/store/stub/StubMenuOptionCommonService.java
+++ b/store/src/test/java/com/food/store/stub/StubMenuOptionCommonService.java
@@ -1,0 +1,70 @@
+package com.food.store.stub;
+
+import com.food.common.menu.business.internal.MenuOptionCommonService;
+import com.food.common.menu.business.internal.dto.MenuOptionDto;
+import com.food.store.mock.MockMenuOption;
+
+import java.util.*;
+
+public class StubMenuOptionCommonService implements MenuOptionCommonService {
+    private final Map<Long, MenuOptionDto> data = new HashMap<>();
+    private Long autoIncrementKey = -1L;
+
+    public MenuOptionDto save(MenuOptionDto menuOption) {
+        if (data.containsKey(menuOption.getId())) {
+            data.put(menuOption.getId(), menuOption);
+            return menuOption;
+        }
+
+        MockMenuOption newOne = MockMenuOption.testBuilder()
+                .id(autoIncrementKey--)
+                .menuId(menuOption.getMenuId())
+                .name(menuOption.getName())
+                .minSize(menuOption.getMinSize())
+                .maxSize(menuOption.getMaxSize())
+                .build();
+        data.put(newOne.getId(), newOne);
+
+        return newOne;
+    }
+
+    public List<MenuOptionDto> saveAll(List<MenuOptionDto> menuOptions) {
+        List<MenuOptionDto> result = new ArrayList<>();
+
+        for (MenuOptionDto eachOption : menuOptions) {
+            result.add(save(eachOption));
+        }
+
+        return result;
+    }
+
+    @Override
+    public Map<Long, List<MenuOptionDto>> findAllByMenuIds(Set<Long> menuIds) {
+        Map<Long, List<MenuOptionDto>> result = new HashMap<>();
+
+        for (MenuOptionDto eachOption : data.values()) {
+            if (menuIds.contains(eachOption.getMenuId())) {
+                putItem(eachOption, result);
+            }
+        }
+
+        return result;
+    }
+
+    private void putItem(MenuOptionDto target, Map<Long, List<MenuOptionDto>> source) {
+        Long targetMenuId = target.getMenuId();
+
+        if (source.containsKey(targetMenuId)) {
+            source.compute(targetMenuId, (key, value)-> {
+                value.add(target);
+                return value;
+            });
+
+        } else {
+            List<MenuOptionDto> value = new ArrayList<>();
+            value.add(target);
+
+            source.put(targetMenuId, value);
+        }
+    }
+}

--- a/store/src/test/java/com/food/store/stub/StubMenuSelectionCommonService.java
+++ b/store/src/test/java/com/food/store/stub/StubMenuSelectionCommonService.java
@@ -1,0 +1,69 @@
+package com.food.store.stub;
+
+import com.food.common.menu.business.internal.MenuSelectionCommonService;
+import com.food.common.menu.business.internal.dto.MenuSelectionDto;
+import com.food.store.mock.MockMenuSelection;
+
+import java.util.*;
+
+public class StubMenuSelectionCommonService implements MenuSelectionCommonService {
+    private final Map<Long, MenuSelectionDto> data = new HashMap<>();
+    private Long autoIncrementKey = -1L;
+
+    public MenuSelectionDto save(MenuSelectionDto menuSelection) {
+        if (data.containsKey(menuSelection.getId())) {
+            data.put(menuSelection.getId(), menuSelection);
+            return menuSelection;
+        }
+
+        MockMenuSelection newOne = MockMenuSelection.testBuilder()
+                .id(autoIncrementKey--)
+                .optionId(menuSelection.getOptionId())
+                .name(menuSelection.getName())
+                .amount(menuSelection.getAmount())
+                .build();
+        data.put(newOne.getId(), newOne);
+
+        return newOne;
+    }
+
+    public List<MenuSelectionDto> saveAll(List<MenuSelectionDto> menuOptions) {
+        List<MenuSelectionDto> result = new ArrayList<>();
+
+        for (MenuSelectionDto eachSelection : menuOptions) {
+            result.add(save(eachSelection));
+        }
+
+        return result;
+    }
+
+    @Override
+    public Map<Long, List<MenuSelectionDto>> findAllByMenuOptionIds(Set<Long> menuOptionIds) {
+        Map<Long, List<MenuSelectionDto>> result = new HashMap<>();
+
+        for (MenuSelectionDto eachSelection : data.values()) {
+            if (menuOptionIds.contains(eachSelection.getOptionId())) {
+                putItem(eachSelection, result);
+            }
+        }
+
+        return result;
+    }
+
+    private void putItem(MenuSelectionDto target, Map<Long, List<MenuSelectionDto>> source) {
+        Long targetOptionId = target.getOptionId();
+
+        if (source.containsKey(targetOptionId)) {
+            source.compute(targetOptionId, (key, value)-> {
+                value.add(target);
+                return value;
+            });
+
+        } else {
+            List<MenuSelectionDto> value = new ArrayList<>();
+            value.add(target);
+
+            source.put(targetOptionId, value);
+        }
+    }
+}


### PR DESCRIPTION
### 가게 전체메뉴 조회 요구사항
- [x] StoreId로 구성된 가게 데이터가 존재해야한다.
- [x] **Store의 메뉴는 1개 이상 존재해야한다.**
- [x] **메뉴 전체목록을 조회한다.**
- [x] **메뉴안에 옵션이 존재할 경우 옵션목록도 함께 가져온다.**

### 리뷰 노트
* 테스트 코드의 Mock객체가 많아지면서 테스트 코드의 리팩토링이 필요해보인다.
* Common 모듈에서 DB 조회 로직은 @DataJpaTest의 테스트환경을 이용하여 기능 구현을 해야겠다.